### PR TITLE
Rename project to "pipes.c" and bin to "pipes-c"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-snake
+pipes-c
 *.swp
 *.o
 Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
-bin_PROGRAMS = pipes-c
-pipes_c_SOURCES = src/pipes-c.c \
+bin_PROGRAMS = cpipes
+cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
 				src/render.c src/render.h \
 				src/util.c src/util.h
-pipes_c_CFLAGS = $(WARN_CFLAGS)
-pipes_c_LDFLAGS = $(WARN_CFLAGS)
-pipes_c_LDADD = $(CURSES_LIBS)
-pipes_c_CPPFLAGS = $(CURSES_CFLAGS)
+cpipes_CFLAGS = $(WARN_CFLAGS)
+cpipes_LDFLAGS = $(WARN_CFLAGS)
+cpipes_LDADD = $(CURSES_LIBS)
+cpipes_CPPFLAGS = $(CURSES_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,9 @@
-bin_PROGRAMS = snake
-snake_SOURCES = src/snake.c \
+bin_PROGRAMS = pipes-c
+pipes_c_SOURCES = src/pipes-c.c \
 				src/pipe.c src/pipe.h \
 				src/render.c src/render.h \
 				src/util.c src/util.h
-snake_CFLAGS = $(WARN_CFLAGS)
-snake_LDFLAGS = $(WARN_CFLAGS)
-snake_LDADD = $(CURSES_LIBS)
-snake_CPPFLAGS = $(CURSES_CFLAGS)
+pipes_c_CFLAGS = $(WARN_CFLAGS)
+pipes_c_LDFLAGS = $(WARN_CFLAGS)
+pipes_c_LDADD = $(CURSES_LIBS)
+pipes_c_CPPFLAGS = $(CURSES_CFLAGS)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Snakes
+# Pipes.c
 
 > *A small piece of software designed to emulate the windows "pipes"
 screensaver in a terminal window.*
@@ -32,11 +32,11 @@ Note that at least version 2.64 of autoconf is required.
 
 ## Usage
 
-To get help, run `snake --help`. In my opinion, the following options are
+To get help, run `pipes-c --help`. In my opinion, the following options are
 especially interesting:
 
-    snake -p30 -r1
-    snake -p100 -r0 -i1
+    pipes-c -p30 -r1
+    pipes-c -p100 -r0 -i1
 
 ## Bugs
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ autoconf-archive are required.
 
 ## Usage
 
-To get help, run `pipes-c --help`. In my opinion, the following options are
+To get help, run `cpipes --help`. In my opinion, the following options are
 especially interesting:
 
-    pipes-c -p30 -r1
-    pipes-c -p100 -r0 -i1
+    cpipes -p30 -r1
+    cpipes -p100 -r0 -i1
 
 ## Bugs
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,11 @@
 AC_PREREQ([2.64])
 
 # Package version from `git describe --always`
-AC_INIT([snake],
+AC_INIT([pipes-c],
         [m4_esyscmd_s([git describe --always])],
         [stefans.mezulis@gmail.com])
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_SRCDIR([src/snake.c])
+AC_CONFIG_SRCDIR([src/pipes-c.c])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_SED
 AC_LANG([C])

--- a/configure.ac
+++ b/configure.ac
@@ -3,11 +3,11 @@
 AC_PREREQ([2.64])
 
 # Package version from `git describe --always`
-AC_INIT([pipes-c],
+AC_INIT([pipes.c],
         [m4_esyscmd_s([git describe --always])],
         [stefans.mezulis@gmail.com])
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_SRCDIR([src/pipes-c.c])
+AC_CONFIG_SRCDIR([src/cpipes.c])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_PROG_SED
 AC_LANG([C])

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -33,7 +33,7 @@ void render(void *data);
 int initial_state = -1;
 
 const char *usage =
-    "Usage: pipes-c [OPTIONS]\n"
+    "Usage: cpipes [OPTIONS]\n"
     "Options:\n"
     "    -p, --pipes=N   Number of pipes.                  (Default: 20    )\n"
     "    -f, --fps=F     Frames per second.                (Default: 60.0  )\n"

--- a/src/pipes-c.c
+++ b/src/pipes-c.c
@@ -33,7 +33,7 @@ void render(void *data);
 int initial_state = -1;
 
 const char *usage =
-    "Usage: snake [OPTIONS]\n"
+    "Usage: pipes-c [OPTIONS]\n"
     "Options:\n"
     "    -p, --pipes=N   Number of pipes.                  (Default: 20    )\n"
     "    -f, --fps=F     Frames per second.                (Default: 60.0  )\n"


### PR DESCRIPTION
The new project name fits with the Pipeseroni convention, and the new binary name is unlikely to conflict with anything already installed.

Suggestions for the name of the binary are welcome. I don't want to include a dot, because it's very uncommon: `ls /usr/bin/*.*` gives less than 1/10 of the executables in that directory, and most of that is version numbering. Just `pipes` wins the autocomplete fight with the other projects in the org, and `pipesc` looks like it should be pronounced "pip esc".

Once we decide on a name, I'll tag the project as 1.0.0, closing #7.