### PR TITLE
Add Travis CI for compilation check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+sudo: required
+
+compiler:
+  - clang
+  - gcc
+
+before_script:
+  - autoreconf -i
+
+script:
+  - ./configure && make && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ compiler:
   - clang
   - gcc
 
+before_install:
+  - AA=autoconf-archive-2017.03.21
+  - wget -O - http://ftpmirror.gnu.org/autoconf-archive/$AA.tar.xz | tar -xJ
+
 before_script:
-  - autoreconf -i
+  - autoreconf -i -I $AA/m4
 
 script:
   - ./configure && make && sudo make install

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Autoconf Archive manually and tell `autoreconf` to use the local copy:
     autoreconf -i -I autoconf-archive/m4
     ./configure && make && make install
 
-Note that at least version 2.64 of autoconf is required.
+Note that at least version 2.64 of autoconf and version 2017.03.21 of
+autoconf-archive are required.
 
 ## Usage
 


### PR DESCRIPTION
* Build on Linux and OS X with Clang and GCC.
* Install autoconf-archive-2017.03.21 (for `AX_IS_RELEASE(dash-version)`).
* Cache autoconf-archive for 1 day.

Here is the [build result](https://travis-ci.org/livibetter/Snakes/builds/343705885).

As we don't have tests (well, not sure how we can do that), this CI is only for the compilation and `make install`.  Invoking Snakes with `-h` (or `-v` soon) wouldn't mean much, nor would `{ sleep 0.1 ; yes ; } | ./snake` (with #14), it runs and that's all.

The caching actually slows down each build for about 10 to 20 seconds, but it won't be downloading autoconf-archive 4 times in every push.

I honestly don't know if we should cache or not, if @StefansM prefers not, I can remove the commit for caching.