### PR TITLE
Strip leading "v" from version tag in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_PREREQ([2.64])
 
 # Package version from `git describe --always`
 AC_INIT([pipes.c],
-        [m4_esyscmd_s([git describe --always])],
+        m4_esyscmd_s([git describe --always | sed 's/^v//' ]),
         [stefans.mezulis@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([src/cpipes.c])


### PR DESCRIPTION
Previously, configure.ac used the latest git tag verbatim as the version number. Version tags are conventionally prefixed with "v", so this commit explicitly strips that prefix.

This is in preparation for finally adding a version number and release (and resolving #7). I'll merge this, tag a release and upload a tarball later today.