### PR TITLE
Support non-UTF-8 character sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ depcomp
 install-sh
 missing
 *.tar.gz
-src/.deps
-src/.dirstamp
+.deps
+.dirstamp
 stamp-h1
+# Don't include test files
+test-suite
+test_locale
+test_locale.*
+test_locale.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ before_script:
 
 script:
   - ./configure && make && sudo make install
+  - make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,9 @@
 bin_PROGRAMS = cpipes
+
+check_PROGRAMS = test_locale
+TEST_LOG_DRIVER = prove
+TESTS = test_locale
+
 cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
 				src/render.c src/render.h \
@@ -7,3 +12,11 @@ cpipes_CFLAGS = $(WARN_CFLAGS)
 cpipes_LDFLAGS = $(WARN_CFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)
 cpipes_CPPFLAGS = $(CURSES_CFLAGS)
+
+test_locale_SOURCES = t/locale.c \
+					  src/pipe.c src/pipe.h \
+					  src/util.c src/util.h
+test_locale_CFLAGS = -I$(srcdir)/src $(WARN_CFLAGS)
+test_locale_LDFLAGS = $(WARN_CFLAGS)
+test_locale_LDADD = $(CURSES_LIBS)
+test_locale_CPPFLAGS = $(CURSES_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,12 @@ AC_PROG_CC_C99
 dnl Obsolete macro, but required by old versions of automake
 AM_PROG_CC_C_O
 
+# Use POSIX 200809L functions.
+# _POSIX_C_SOURCE >= 200809L should be equivalent to _XOPEN_SOURCE >= 700,
+# but at least on RHEL7 it is not.
+AC_DEFINE([_POSIX_C_SOURCE], [200809L], [Use POSIX 200809L features])
+AC_DEFINE([_XOPEN_SOURCE], [700], [Use POSIX 200809L features])
+
 # Non-release versions have a dash (e.g. 0.0.1-1-g1abcde)
 AX_IS_RELEASE([dash-version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,9 @@ WARN_CFLAGS=$(AS_ECHO(["$WARN_CFLAGS"]) | dnl
               $SED 's/-W\(error=\)\?declaration-after-statement *//g')
 AC_SUBST([WARN_CFLAGS])
 
+AC_SEARCH_LIBS([iconv], [iconv], [],
+               [AC_MSG_ERROR(["iconv is required for locale conversion"])])
+
 # Use noreturn attribute if available
 AC_CHECK_HEADERS_ONCE([stdnoreturn.h])
 

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 199309L
-#define _XOPEN_SOURCE_EXTENDED 1
 #include <config.h>
 
 #include <langinfo.h>

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <errno.h>
 #include <iconv.h>
 #include <langinfo.h>

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -1,46 +1,307 @@
+#include <errno.h>
+#include <iconv.h>
+#include <langinfo.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
+#include <wchar.h>
 #include "pipe.h"
 #include "util.h"
+
+/* This file contains functions for managing the initialisation and movement of
+ * a pipe.
+ *
+ * We want to take advantage of all the unicode characters for box drawing, so
+ * there are some subtleties we have to take into account:
+ *
+ * - Pipe characters may consist of multiple bytes.
+ *
+ * - Predefined pipe characters in these source files are encoded in UTF-8, but
+ *   characters supplied by the user will be in their locale encoding.
+ *
+ * - In some encodings, characters can print over multiple columns on the
+ *   terminal. For example, "━" and "┃" in GB18030 will span two columns.
+ *
+ * To cope with this, the general strategy for building transition and
+ * continuation matrices is:
+ *
+ * 1. Call `locale_to_utf8` to convert the list of pipe characters into a UTF-8
+ *    encoded string. If the supplied characters are hard-coded presets or the
+ *    user's locale is (sensibly) using UTF-8, this will simply copy the bytes.
+ *    We do this because it is trivial to split a UTF-8-encoded string into
+ *    characters, but impossible in an arbitrary encoding without prior
+ *    knowledge of the encoding scheme.
+ *
+ * 2. Call `utf8_to_locale` with the UTF-8-encoded bytes to convert the pipe
+ *    characters into a nul-separated list of multibyte characters encoded in
+ *    the user's locale.
+ *
+ * 3. Call `assign_matrices` to assign the nul-separated locale-encoded
+ *    characters to the transition matrix and list of continuation characters.
+ *
+ * 4. Call `multicolumn_adjust` to detect any characters that are encoded in
+ *    multiple columns. This will adjust the values of the `states` global,
+ *    ensuring that we always move the cursor by the correct increment. This
+ *    affects the functions `wrap_pipe`, `move_pipe` and `init_pipe`, which
+ *    must take care not to let half a multicolumn character fall of the right
+ *    margin of the terminal and not to initialise pipes on half-character
+ *    boundaries.
+ */
+
+static bool utf8_continuation(char byte);
+static size_t charwidth(const char *pipe_char);
 
 //The states describe the current "velocity" of a pipe.  Notice that the allowed
 //transitions are given by a change of +/- 1. So, for example, a pipe heading
 //left may go up or down but not right.
 //              Right    Down   Left    Up
-const char states[][2] = {{1,0}, {0,1}, {-1,0}, {0,-1}};
+char states[][2] = {{1,0}, {0,1}, {-1,0}, {0,-1}};
 
-//The transition matrices here describe the character that should be output upon
-//a transition from] one state (direction) to another. If you wanted, you could
-//modify these to include the probability of a transition.
-//┓ : U+2513
-//┛ : U+251B
-//┗ : U+2517
-//┏ : U+250F
-const char* trans_unicode[]  = {
-//      R D L U
-    "",         "\u2513",     "",          "\u251B", //R
-    "\u2517",    "",          "\u251B",     0      , //D
-    "",         "\u250F",     "",          "\u2517", //L
-    "\u250F",    "",          "\u2513",     0        //D
-};
-const char* trans_ascii[] = {
-//       R D L U
-    "",     "+",    "",      "+", //R
-    "+",   "",      "+",    0   , //D
-    "",     "+",    "",      "+", //L
-    "+",   "",      "+",    0     //U
-};
-
-const char * transition_char(const char **list, int row, int col){
+const char * transition_char(char **list, int row, int col){
     return list[row * 4 + col];
 }
 
-//The characters to represent a travelling (or extending, I suppose) pipe.
-const char* unicode_pipe_chars[] = {"\u2501", "\u2503"};
-const char* ascii_pipe_chars[]   = {"-", "|"};
+// Number of columns used on the terminal to print a given pipe character.
+static size_t charwidth(const char *pipe_char) {
+    size_t nwide = mbstowcs(NULL, pipe_char, 0);
+    if(nwide == (size_t) -1)
+        return (size_t) -1;
+    wchar_t wide_buf[nwide + 1];
+    mbstowcs(wide_buf, pipe_char, nwide);
+    return (size_t) wcswidth(wide_buf, nwide);
+}
 
+/** UTF-8 encoded characters have the top two bits encoded as 0b10 if they are
+ * continution characters. That is, they can only be seen after a
+ * character-start byte.
+*/
+static bool utf8_continuation(char byte) {
+    return ((byte >> 6) & 0b11) == 0b10;
+}
+
+/** Convert characters encoded in the user's locale (`from_charset`) to our
+ * internal representation, which is UTF-8. This function assumes that
+ * `locale_bytes` is nul terminated.
+ *
+ * locale_bytes:
+ *      Input bytes, representing some string of characters in `from_charset`.
+ *
+ * utf8_bytes:
+ *      Output bytes, representing the same characters but encoded in UTF-8.
+ *
+ * from_charset:
+ *      The name of the character set encoding `locale_bytes`.
+ *
+ * buflen:
+ *      Space in bytes available in `utf8_bytes`.
+ *
+ * This function will return 0 upon success, or -1 upon error. Error messages
+ * will be written to standard output.
+ */
+int locale_to_utf8(char *locale_bytes, char *utf8_bytes,
+        const char *from_charset, size_t buflen) {
+    if(!strcmp(from_charset, "UTF-8")){
+        // No need to run iconv if we are already in UTF-8
+        if(strlen(locale_bytes) >= buflen){
+            fprintf(stderr, "Output buffer too small.\n");
+            return -1;
+        }
+        strncpy(utf8_bytes, locale_bytes, buflen);
+        return 0;
+    }
+
+    iconv_t cd = iconv_open("UTF-8", from_charset);
+    if(cd == (iconv_t) -1) {
+        perror("Error intialising iconv for charset conversion.");
+        return -1;
+    }
+
+    // Length of string plus terminating nul byte, which we also want to
+    // encode.
+    size_t in_left = strlen(locale_bytes) + 1;
+    size_t out_left = buflen;
+    size_t nconv = iconv(cd, &locale_bytes, &in_left, &utf8_bytes, &out_left);
+
+    if(nconv == (size_t) -1){
+        perror("Error converting pipe chars to UTF-8");
+        iconv_close(cd);
+        return -1;
+    }
+    iconv_close(cd);
+    return 0;
+}
+
+
+/** Convert a set of *characters* encoded in UTF-8 into nul-separated
+ * characters in `to_charset`. This function is used to split a UTF-8 encoded
+ * string of characters into a locale-encoded string. Nul bytes are inserted
+ * between each character in the encoded string.
+ *
+ * We do this because it is very easy to split characters in UTF-8, but very
+ * difficult to do so in an arbitrary character set.
+ *
+ * This function assumes that bare nul bytes are not valid in `to_charset`.
+ * Since this is the user's locale, this is a fair assumption: it would take
+ * real dedication (and masochism) to use an encoding that breaks C's
+ * assumption about string termination.
+ *
+ * utf8_chars:
+ *      Input buffer containing a UTF-8-encoded string of characters.
+ *
+ * out_chars:
+ *      Output buffer that will contain `to_charset` encoded string of
+ *      nul-separated characters.
+ *
+ * buflen:
+ *      Size in bytes of the `out_chars` buffer.
+ *
+ * to_charset:
+ *      Name of the character set into which we are converting.
+ *
+ * This function will return 0 on success or -1 on failre. Error messages are
+ * printed to stderr on error.
+ */
+int utf8_to_locale(
+        char *utf8_chars,
+        char *out_chars, size_t buflen,
+        const char *to_charset){
+
+    iconv_t cd = iconv_open(to_charset, "UTF-8");
+    if(cd == (iconv_t) -1){
+        perror("Error converting characters");
+        return -1;
+    }
+
+    char *utf8_char_start = utf8_chars;
+    char *locale_char_start = out_chars;
+    size_t remaining_bytes = buflen - 1;
+
+    // i is index into utf8 array
+    for(size_t i = 1; i <= strlen(utf8_chars); i++) {
+        if(remaining_bytes <= 0){
+            fprintf(stderr, "Output buffer too small\n");
+            iconv_close(cd);
+            return -1;
+        }
+
+        if(!utf8_continuation(utf8_chars[i])) {
+            // Convert a single character
+            size_t inbytes = (size_t) (&utf8_chars[i] - utf8_char_start);
+            size_t nconv = iconv(cd,
+                &utf8_char_start, &inbytes,
+                &locale_char_start, &remaining_bytes);
+            if(nconv == (size_t) -1){
+                perror("Error converting UTF8 to target locale");
+                iconv_close(cd);
+                return -1;
+            }
+            (*locale_char_start) = '\0';
+            locale_char_start++;
+            remaining_bytes--;
+        }
+    }
+    iconv_close(cd);
+    return 0;
+}
+
+/** Assign transition and continuation characters from nul-separated multibyte
+ * characters in `pipe_chars`.
+ *
+ * The input buffer must contain six characters in the order ━┃┓┛┗┏. If fewer
+ * than six characters are present, then this function will continute to read
+ * until it hits a nul character somewhere in memory.
+ *
+ * pipe_chars:
+ *      Input buffer containing 6 nul-separated multibyte characters to be
+ *      assigned to `transition` and `continuation`. The `char *` pointers
+ *      in `transition` and `continuation` point to characters *in this
+ *      buffer*, so you can't free this and expect `transition` or
+ *      `continuation` to remain valid.
+ *
+ * transition:
+ *      Row-major 4x4 transition matrix. Entries in this matrix initialised
+ *      to NULL. Pointers to the transition characters are placed in this
+ *      matrix.
+ *
+ * continuation:
+ *      Two-character list containing the horizontal and vertical continuation
+ *      characters.
+ *
+ * This function will return 0 on success or -1 on error.
+ */
+int assign_matrices(char *pipe_chars,
+        char **transition, char **continuation) {
+
+    continuation[0] = continuation[1] = NULL;
+    for(size_t i = 0; i < 16; i++)
+        transition[i] = NULL;
+
+    size_t nchars = 0;
+    char *c = pipe_chars;
+    // "i" indexes bytes, "nchars" indexes characters.
+    // "nchars" and "c" are set after the switch statement.
+    for(size_t i = 0; nchars < 6; i++){
+        if(pipe_chars[i] != '\0')
+            continue;
+        switch(nchars) {
+            // Pipe continuation characters ━,┃
+            case 0:
+            case 1:
+                continuation[nchars] = c;
+                break;
+            // Transition chars go ┓,┛,┗,┏
+            case 2:
+                transition[RIGHT * 4 + DOWN] = c;
+                transition[UP * 4 + LEFT] = c;
+                break;
+            case 3:
+                transition[RIGHT * 4 + UP] = c;
+                transition[DOWN * 4 + LEFT] = c;
+                break;
+            case 4:
+                transition[LEFT * 4 + UP] = c;
+                transition[DOWN * 4 + RIGHT] = c;
+                break;
+            case 5:
+                transition[LEFT * 4 + DOWN] = c;
+                transition[UP * 4 + RIGHT] = c;
+                break;
+            default:
+                // No way to reach here.
+                return -1;
+        }
+        nchars++;
+        c = &pipe_chars[i + 1];
+    }
+    return 0;
+}
+
+/** Adjust possible states (i.e. the `states` global) to reflect width of
+ * continuation chars. If the pipe continuation characters take two columns to
+ * display, alter the possible left/right pipe velocities to reflect that.
+ *
+ * This function will return -1 on error (e.g. invalid byte sequence) or 0
+ * on success.
+ */
+int multicolumn_adjust(char **continuation) {
+    size_t width = max(charwidth(continuation[0]), charwidth(continuation[1]));
+    if(width == (size_t) -1)
+        return -1;
+    states[0][0] = width;
+    states[2][0] = -width;
+    return 0;
+}
+
+/** Initialise a pipe. If there are multicolumn characters in use, this
+ * function makes sure to only assign initial positions at full-character
+ * boundaries.
+ */
 void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
         int width, int height){
+    // Multicolumn chars shouldn't be placed off the end of the screen
+    size_t colwidth = max(states[0][0], -states[2][0]);
+    width -= width % colwidth;
 
     if(initial_state < 0)
         pipe->state = randrange(0, 4);
@@ -48,17 +309,29 @@ void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
         pipe->state = initial_state;
     pipe->colour = randrange(0, ncolours);
     pipe->length = 0;
-    pipe->x = randrange(0, width);
-    pipe->y = randrange(0, height);
+    pipe->x = randrange(0, width / colwidth) * colwidth;
+    pipe->y = randrange(0, height / colwidth) * colwidth;
 }
 
+/** Move a pipe by the amount given by the current state. If
+ * `multicolumn_adjust` was called and detected that multicolumn characters are
+ * in use, the `states` variable will have been updated to reflect the width of
+ * the largest character in use.
+ */
 void move_pipe(struct pipe *pipe){
     pipe->x += states[pipe->state][0];
     pipe->y += states[pipe->state][1];
     pipe->length++;
 }
 
+/** Wrap a pipe at terminal boundaries.  If there are multi-column continuation
+ * characters, wrap the pipe before it gets a chance to spit out incomplete
+ * characters.
+ */
 bool wrap_pipe(struct pipe *pipe, int width, int height){
+    // Take multi-column chars into account
+    width -= width % max(states[0][1], -states[2][0]);
+
     if(pipe->x < 0 || pipe->x == width
             || pipe->y < 0 || pipe->y == height){
         if(pipe->x < 0){ pipe->x += width; }

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -1,12 +1,20 @@
 #ifndef PIPE_H_
 #define PIPE_H_
 
-//States and transition characters
-extern const char states[][2];
+#include <stddef.h>
+#include <stdbool.h>
 
-//The characters to represent a travelling (or extending, I suppose) pipe.
-extern const char* unicode_pipe_chars[];
-extern const char* ascii_pipe_chars[];
+//States and transition characters
+extern char states[][2];
+
+// Maximum number of bytes per character
+#define MAX_CHAR_BYTES 10
+
+/** 2 continuation chars, 4 transition chars, 6 delimiting nuls.  Entries in
+ * the transition matrix and list of continuation chars point to chars in this
+ * buffer, which will contain multiple \0s.
+ */
+#define CHAR_BUF_SZ (6 * MAX_CHAR_BYTES + 6)
 
 //Represents a pipe
 struct pipe {
@@ -15,6 +23,14 @@ struct pipe {
     unsigned short length;
     int x, y;
 };
+
+enum DIRECTIONS {
+    RIGHT = 0,
+    DOWN = 1,
+    LEFT = 2,
+    UP = 3
+};
+
 
 void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
         int width, int height);
@@ -25,8 +41,16 @@ void random_pipe_colour(struct pipe *pipe, int ncolours);
 bool should_flip_state(struct pipe *p, int min_len, float prob);
 char pipe_char(struct pipe *p, char old_state);
 
-extern const char *trans_ascii[];
-extern const char *trans_unicode[];
-const char * transition_char(const char **list, int row, int col);
+const char * transition_char(char **list, int row, int col);
+
+int locale_to_utf8(char *locale_bytes, char *utf8_bytes,
+        const char *from_charset, size_t buflen);
+int utf8_to_locale(
+        char *utf8_chars,
+        char *out_chars, size_t buflen,
+        const char *to_charset);
+int assign_matrices(char *pipe_chars,
+        char **transition, char **continuation);
+int multicolumn_adjust(char **continuation);
 
 #endif //PIPE_H_

--- a/src/render.c
+++ b/src/render.c
@@ -2,6 +2,7 @@
 #include <time.h>
 #include <signal.h>
 #include <curses.h>
+#include <stdlib.h>
 #include "render.h"
 #include "pipe.h"
 
@@ -46,14 +47,15 @@ void animate(int fps, anim_function renderer,
     }
 }
 
-void render_pipe(struct pipe *p, const char **trans, const char **pipe_chars,
+void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state){
 
     move(p->y, p->x);
     attron(COLOR_PAIR(p->colour));
-    if(old_state != new_state)
+    if(old_state != new_state) {
         addstr(transition_char(trans, old_state, new_state));
-    else
+    }else{
         addstr(pipe_chars[old_state % 2]);
+    }
     attroff(COLOR_PAIR(p->colour));
 }

--- a/src/render.c
+++ b/src/render.c
@@ -1,4 +1,5 @@
-#define _POSIX_C_SOURCE 199309L
+#include <config.h>
+
 #include <time.h>
 #include <signal.h>
 #include <curses.h>

--- a/src/render.h
+++ b/src/render.h
@@ -7,7 +7,7 @@ typedef void (*anim_function)(void *data);
 void init_colours(void);
 void animate(int fps, anim_function renderer,
         volatile sig_atomic_t *interrupted, void *data);
-void render_pipe(struct pipe *p, const char **trans, const char **pipe_chars,
+void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);
 
 #endif //RENDER_H_

--- a/src/util.c
+++ b/src/util.c
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include <assert.h>
 #include <stdlib.h>
 #include <stdbool.h>

--- a/t/locale.c
+++ b/t/locale.c
@@ -1,7 +1,10 @@
-#include "pipe.h"
+#include <config.h>
+
 #include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
+
+#include "pipe.h"
 /**
  * Check locale-encoding functions.
  */

--- a/t/locale.c
+++ b/t/locale.c
@@ -1,0 +1,133 @@
+#include "pipe.h"
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+/**
+ * Check locale-encoding functions.
+ */
+#define NUM_TESTS 29
+
+// TAP-producing ok() function
+static int testnum = 0;
+static void ok(bool condition, const char* msg);
+static void ok(bool condition, const char* msg) {
+    printf("%s %d - %s\n", condition ? "ok" : "not ok", testnum++, msg);
+}
+
+// These are the same in UTF8 and GB18030
+const char *UTF8_ASCII = "123";
+const char *GB18030_ASCII = "\x31\x32\x33";
+const char *GB18030_ASCII_SPLIT = "\x31\0\x32\0\x33";
+
+// These higher characters do differ: ━┃
+const char *UTF8_BOX = "\xE2\x94\x81\xE2\x94\x83";
+const char *GB18030_BOX = "\xA9\xA5\xA9\xA7";
+const char *GB18030_BOX_SPLIT = "\xA9\xA5\0\xA9\xA7";
+
+// Assigned to by assign_matrices
+const char *test_pipe_chars = "1\0" "2\0" "3\0" "4\0" "5\0" "6";
+char *transition[16];
+char *continuation[2];
+
+int main(int argc, char **argv) {
+    int r;
+
+    size_t bufsz = 10;
+    char in[bufsz];
+    char out[bufsz];
+
+    printf("1..%d\n", NUM_TESTS);
+
+    // Identity conversion with ASCII bytes
+    strcpy(in, UTF8_ASCII);
+    r = locale_to_utf8(in, out, "UTF-8", 4);
+    ok(r == 0,
+        "ASCII UTF8 to UTF8 in 4 bytes: no error code.");
+    ok(strcmp(out, UTF8_ASCII) == 0,
+        "ASCII UTF8 to UTF8 copied correctly");
+
+    r = locale_to_utf8(in, out, "UTF-8", 3);
+    ok(r == -1,
+        "ASCII UTF8 to UTF8 in 3 bytes: buffer too small.");
+
+    // Identity conversion with higher bytes
+    strcpy(in, UTF8_BOX);
+    r = locale_to_utf8(in, out, "UTF-8", 7);
+    ok(r == 0,
+        "Box UTF8 to UTF8 in 7 bytes: no error code.");
+    ok(strcmp(out, UTF8_BOX) == 0,
+        "Box UTF8 to UTF8 copied correctly.");
+
+    r = locale_to_utf8(in, out, "UTF-8", 6);
+    ok(r == -1,
+        "Box UTF8 to UTF8 in 6 bytes: buffer too small.");
+
+    // Convert GB18030 to UTF-8 with ASCII bytes (no change)
+    strcpy(in, GB18030_ASCII);
+    r = locale_to_utf8(in, out, "GB18030", 4);
+    ok(r == 0,
+        "ASCII GB18030 to UTF8 in 4 bytes: no error code.");
+    ok(strcmp(out, UTF8_ASCII) == 0,
+        "ASCII UTF8 to GB18030 copied correctly");
+
+    r = locale_to_utf8(in, out, "GB18030", 3);
+    ok(r == -1,
+        "ASCII GB18030 to UTF8 in 3 bytes: buffer too small.");
+
+    // Convert GB18030 to UTF-8 with box-drawing chars
+    strcpy(in, GB18030_BOX);
+    r = locale_to_utf8(in, out, "GB18030", 7);
+    ok(r == 0,
+        "Box GB18030 to UTF8 in 7 bytes: no error code.");
+    ok(strcmp(out, UTF8_BOX) == 0,
+        "Box GB18030 to UTF8 copied correctly.");
+
+    r = locale_to_utf8(in, out, "GB18030", 6);
+    ok(r == -1,
+        "Box GB18030 to UTF8 in 6 bytes: buffer too small.");
+
+    // Convert UTF-8 to GB18030 with ASCII bytes
+    strcpy(in, UTF8_ASCII);
+    r = utf8_to_locale(in, out, 6, "GB18030");
+    ok(r == 0,
+        "ASCII UTF8 to GB18030 in 6 bytes: no error code.");
+    ok(memcmp(out, GB18030_ASCII_SPLIT, 6) == 0,
+        "ASCII UTF8 to GB18030 copied correctly.");
+
+    r = utf8_to_locale(in, out, 5, "GB18030");
+    ok(r == -1,
+        "ASCII UTF8 to GB18030 in 5 bytes: buffer too small.");
+
+    // Convert UTF-8 to GB18030 with box-drawing bytes
+    strcpy(in, UTF8_BOX);
+    r = utf8_to_locale(in, out, 6, "GB18030");
+    ok(r == 0,
+        "Box UTF8 to GB18030 in 6 bytes: no error code.");
+    ok(memcmp(out, GB18030_BOX_SPLIT, 6) == 0,
+        "Box UTF8 to GB18030 copied correctly.");
+
+    r = utf8_to_locale(in, out, 5, "GB18030");
+    ok(r == -1,
+        "Box UTF8 to GB18030 in 5 bytes: buffer too small.");
+
+    // Assign transition and continuation matrices
+    strcpy(in, test_pipe_chars);
+    r = assign_matrices(in, transition, continuation);
+    ok(r == 0, "No error assigning matrices.");
+
+    ok(!strcmp(continuation[0], "1"), "HORIZONTAL");
+    ok(!strcmp(continuation[1], "2"), "VERTICAL");
+
+    ok(!strcmp(transition[RIGHT * 4 + DOWN], "3"), "RIGHT / DOWN");
+    ok(!strcmp(transition[UP * 4 + LEFT], "3"), "UP / LEFT");
+
+    ok(!strcmp(transition[RIGHT * 4 + UP], "4"), "RIGHT / UP");
+    ok(!strcmp(transition[DOWN * 4 + LEFT], "4"), "DOWN / LEFT");
+
+    ok(!strcmp(transition[LEFT * 4 + UP], "5"), "LEFT / UP");
+    ok(!strcmp(transition[DOWN * 4 + RIGHT], "5"), "DOWN / RIGHT");
+
+    ok(!strcmp(transition[LEFT * 4 + DOWN], "6"), "LEFT / DOWN");
+    ok(!strcmp(transition[UP * 4 + RIGHT], "6"), "UP / RIGHT");
+    return 0;
+}


### PR DESCRIPTION
This commit modifies `cpipes` to use `iconv` to convert the internally-encoded pipe character lists, which are in UTF-8, to the user's locale (#9). As a bonus, it includes functions to convert from the user's locale *into* UTF-8, so it is now trivial to add custom lists of characters.

The implementation details are described in the comment at the head of `pipes.c`, so I won't re-hash them here.

As an example of this in action, here is the previous version (before this commit) running in `urxvt` in a GB18030 locale:
![gb18030-broken](https://user-images.githubusercontent.com/396334/36644772-1ddfd144-1a57-11e8-8e89-0c0e1c64159b.png)
Very matrix-esque, but not what we're looking for.

After this commit, it looks like this, as intended:
![gb18030-working](https://user-images.githubusercontent.com/396334/36644789-47d397b0-1a57-11e8-8e37-744e12a83d4a.png)

There are some problems with this, which I think are mostly caused by multi-column characters. For example, xterm is still quite broken:
![gb18030-xterm-broken](https://user-images.githubusercontent.com/396334/36644806-77d0cf5a-1a57-11e8-91c0-5e130861f850.png)

Interestingly, increasing the number of pipes fixes some of the alignment problems in xterm:
![gb18030-xterm-less-broken](https://user-images.githubusercontent.com/396334/36644811-8fda7ace-1a57-11e8-88c6-1c5e41d56238.png)
This leads me to think it may be related to ncurses' local move optimisations, as having two pipes will mean ncurses prefers to use `cup` rather than local moves like `\b\b\b`. I don't know whether the fault lies in ncurses (unlikely), terminfo (possible) or xterm (possible), and I don't care nearly enough to find out.

This commit also adds a unit test for the locale conversion. I've included an update Travis CI config that runs the unit test using `prove` as a test runner, which should be present on most dev machines.