### PR TITLE
Add handler for window size change

### DIFF
--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -28,7 +28,7 @@ float parse_float_opt(const char *optname);
 int parse_int_opt(const char *optname);
 noreturn void die(void);
 void usage_msg(int exitval);
-void render(void *data);
+void render(unsigned int width, unsigned int height, void *data);
 int init_chars(void);
 
 //If set >= zero, this initial state is used.
@@ -63,7 +63,7 @@ struct pipe *pipes;
 volatile sig_atomic_t interrupted = 0;
 
 //Width and height of terminal (in chars and lines)
-unsigned int width, height;
+unsigned int screen_width, screen_height;
 
 unsigned int num_pipes = 20;
 float fps = 60;
@@ -123,15 +123,16 @@ int main(int argc, char **argv){
     curs_set(0);
     cbreak();
     nodelay(stdscr, true);
-    getmaxyx(stdscr, height, width);
+    getmaxyx(stdscr, screen_height, screen_width);
     init_colours();
 
     //Init pipes. Use predetermined initial state, if any.
     pipes = malloc(num_pipes * sizeof(struct pipe));
     for(unsigned int i=0; i<num_pipes;i++)
-        init_pipe(&pipes[i], COLORS, initial_state, width, height);
+        init_pipe(&pipes[i], COLORS, initial_state,
+            screen_width, screen_height);
 
-    animate(fps, render, &interrupted, NULL);
+    animate(fps, render, &screen_width, &screen_height, &interrupted, NULL);
 
     curs_set(1);
     endwin();
@@ -139,7 +140,7 @@ int main(int argc, char **argv){
     return 0;
 }
 
-void render(void *data){
+void render(unsigned int width, unsigned int height, void *data){
     for(size_t i=0; i<num_pipes && !interrupted; i++){
         move_pipe(&pipes[i]);
         if(wrap_pipe(&pipes[i], width, height))

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -334,8 +334,8 @@ bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height){
     // Take multi-column chars into account
     width -= width % max(states[0][1], -states[2][0]);
 
-    if(pipe->x < 0 || (unsigned int) pipe->x == width
-            || pipe->y < 0 || (unsigned int) pipe->y == height){
+    if(pipe->x < 0 || (unsigned int) pipe->x >= width
+            || pipe->y < 0 || (unsigned int) pipe->y >= height){
         if(pipe->x < 0){ pipe->x += width; }
         if(pipe->y < 0){ pipe->y += height; }
         if((unsigned int) pipe->x >= width) {pipe->x -= width; }

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -300,7 +300,7 @@ int multicolumn_adjust(char **continuation) {
  * boundaries.
  */
 void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
-        int width, int height){
+        unsigned int width, unsigned int height){
     // Multicolumn chars shouldn't be placed off the end of the screen
     size_t colwidth = max(states[0][0], -states[2][0]);
     width -= width % colwidth;
@@ -330,16 +330,16 @@ void move_pipe(struct pipe *pipe){
  * characters, wrap the pipe before it gets a chance to spit out incomplete
  * characters.
  */
-bool wrap_pipe(struct pipe *pipe, int width, int height){
+bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height){
     // Take multi-column chars into account
     width -= width % max(states[0][1], -states[2][0]);
 
-    if(pipe->x < 0 || pipe->x == width
-            || pipe->y < 0 || pipe->y == height){
+    if(pipe->x < 0 || (unsigned int) pipe->x == width
+            || pipe->y < 0 || (unsigned int) pipe->y == height){
         if(pipe->x < 0){ pipe->x += width; }
         if(pipe->y < 0){ pipe->y += height; }
-        if(pipe->x >= width) {pipe->x -= width; }
-        if(pipe->y >= height) {pipe->y -= height; }
+        if((unsigned int) pipe->x >= width) {pipe->x -= width; }
+        if((unsigned int) pipe->y >= height) {pipe->y -= height; }
         return true;
     }
     return false;

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -33,9 +33,9 @@ enum DIRECTIONS {
 
 
 void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
-        int width, int height);
+        unsigned int width, unsigned int height);
 void move_pipe(struct pipe *pipe);
-bool wrap_pipe(struct pipe *pipe, int width, int height);
+bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height);
 char flip_pipe_state(struct pipe *pipe);
 void random_pipe_colour(struct pipe *pipe, int ncolours);
 bool should_flip_state(struct pipe *p, int min_len, float prob);

--- a/src/render.c
+++ b/src/render.c
@@ -26,8 +26,18 @@ void animate(int fps, anim_function renderer,
     struct timespec start_time;
     long delay_ns = NS / fps;
 
+    // Continue while we haven't received a SIGINT
+    while(!(*interrupted)){
+        int key = getch();
 
-    while(!(*interrupted) && getch() == ERR){
+        // If we received a SIGWINCH, update width and height
+        if(key == KEY_RESIZE) {
+            getmaxyx(stdscr, *height, *width);
+        }else if(key != ERR) {
+            // Any actual keypresses should quit the program.
+            break;
+        }
+
         clock_gettime(CLOCK_REALTIME, &start_time);
 
         //Render

--- a/src/render.c
+++ b/src/render.c
@@ -20,6 +20,7 @@ void init_colours(void){
 }
 
 void animate(int fps, anim_function renderer,
+        unsigned int *width, unsigned int *height,
         volatile sig_atomic_t *interrupted, void *data){
     //Store start time
     struct timespec start_time;
@@ -30,7 +31,7 @@ void animate(int fps, anim_function renderer,
         clock_gettime(CLOCK_REALTIME, &start_time);
 
         //Render
-        (*renderer)(data);
+        (*renderer)(*width, *height, data);
 
         //Get end time
         struct timespec end_time;

--- a/src/render.h
+++ b/src/render.h
@@ -2,10 +2,12 @@
 #define RENDER_H_
 #include "pipe.h"
 
-typedef void (*anim_function)(void *data);
+typedef void (*anim_function)(unsigned int width, unsigned int height,
+        void *data);
 
 void init_colours(void);
 void animate(int fps, anim_function renderer,
+        unsigned int *width, unsigned int *height,
         volatile sig_atomic_t *interrupted, void *data);
 void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);


### PR DESCRIPTION
This uses ncurses' built-in SIGWINCH handler to track resize events. This well and truly ties us to ncurses rather than any other curses library, but that's academic: I've never seen a curses library in use other than ncurses, and the code is already written in C99 :)

Resizing the window as quickly as I can take a screenshot goes from this:
![cpipes-small](https://user-images.githubusercontent.com/396334/36763255-163f85dc-1c1f-11e8-87ba-c7dfd857f53b.png)
To this:
![cpipes-big](https://user-images.githubusercontent.com/396334/36763261-19e266c8-1c1f-11e8-8e7a-17dbbeda4342.png)