### PR TITLE
Misc bugfixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,8 +36,12 @@ WARN_CFLAGS=$(AS_ECHO(["$WARN_CFLAGS"]) | dnl
               $SED 's/-W\(error=\)\?declaration-after-statement *//g')
 AC_SUBST([WARN_CFLAGS])
 
+# OSX requires linking against libiconv
 AC_SEARCH_LIBS([iconv], [iconv], [],
                [AC_MSG_ERROR(["iconv is required for locale conversion"])])
+# Some systems require librt for clock_gettime
+AC_SEARCH_LIBS([clock_gettime], [rt], [],
+               [AC_MSG_ERROR(["clock_gettime is required for timing"])])
 
 # Use noreturn attribute if available
 AC_CHECK_HEADERS_ONCE([stdnoreturn.h])

--- a/src/util.c
+++ b/src/util.c
@@ -7,6 +7,9 @@
 
 ///Get a random integer in the range [lo, hi).
 int randrange(int lo, int hi){
+    assert(lo <= hi /* Negative range not allowed. */);
+    if(lo == hi)
+        return lo;
     return randint(lo, hi - 1);
 }
 


### PR DESCRIPTION
Fixes an assertion error when `COLORS == 1` and a build error on old machines that require linking against `librt` for `clock_gettime`.