### PR TITLE
Take advantage of all terminal colours (#10)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ TESTS = test_locale
 cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
 				src/render.c src/render.h \
-				src/util.c src/util.h
+				src/util.c src/util.h \
+				src/err.c src/err.h
 cpipes_CFLAGS = $(WARN_CFLAGS)
 cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 bin_PROGRAMS = cpipes
 
 check_PROGRAMS = test_locale
-TEST_LOG_DRIVER = prove
 TESTS = test_locale
 
 cpipes_SOURCES = src/cpipes.c \
@@ -16,7 +15,8 @@ cpipes_CPPFLAGS = $(CURSES_CFLAGS)
 
 test_locale_SOURCES = t/locale.c \
 					  src/pipe.c src/pipe.h \
-					  src/util.c src/util.h
+					  src/util.c src/util.h \
+					  src/err.c src/err.h
 test_locale_CFLAGS = -I$(srcdir)/src $(WARN_CFLAGS)
 test_locale_LDFLAGS = $(WARN_LDFLAGS)
 test_locale_LDADD = $(CURSES_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,32 @@ AX_IS_RELEASE([dash-version])
 # Require curses
 AX_WITH_CURSES
 
+
+libs=$LIBS
+LIBS=$CURSES_LIBS
+
+# Macro for checking for a particular function in all libraies in LIBS
+# have_function([preamble], [function(1, 2, 3)], [symbol to define])
+AC_DEFUN([have_fn], [dnl
+    AC_MSG_CHECKING([for $2])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([$1],
+                                    [$2;])],
+                   [AC_DEFINE([$3],
+                              [1],
+                              [have $2])
+                    AC_MSG_RESULT([yes])],
+                   [AC_MSG_RESULT([no])])
+])
+have_fn([#include <curses.h>],
+        [init_extended_color(0, 0, 0, 0)],
+        [HAVE_EXTENDED_COLOR])
+
+have_fn([#include <curses.h>],
+        [alloc_pair(0, 0)],
+        [HAVE_ALLOC_PAIR])
+
+LIBS=$libs
+
 # Enable as many compiler warnings as possible
 AX_COMPILER_FLAGS()
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,10 @@ AC_SEARCH_LIBS([iconv], [iconv], [],
 AC_SEARCH_LIBS([clock_gettime], [rt], [],
                [AC_MSG_ERROR(["clock_gettime is required for timing"])])
 
+# Some systems require libm for certain math functions
+AC_SEARCH_LIBS([fmod], [m], [],
+               [AC_MSG_ERROR(["fmod is required"])])
+
 # Use noreturn attribute if available
 AC_CHECK_HEADERS_ONCE([stdnoreturn.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,9 @@ AC_SEARCH_LIBS([clock_gettime], [rt], [],
 AC_SEARCH_LIBS([fmod], [m], [],
                [AC_MSG_ERROR(["fmod is required"])])
 
+# Check for format attribute
+AX_GCC_FUNC_ATTRIBUTE([format])
+
 # Use noreturn attribute if available
 AC_CHECK_HEADERS_ONCE([stdnoreturn.h])
 

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -124,14 +124,20 @@ int main(int argc, char **argv){
     initscr();
     curs_set(0);
     cbreak();
-    nodelay(stdscr, true);
+    noecho();
+    setbuf(stdout, NULL);
     getmaxyx(stdscr, screen_height, screen_width);
 
-    int err = init_colour_palette(NULL, 0, &palette);
+    struct color_backup backup;
+    int err = init_colour_palette(NULL, 0, &palette, &backup);
     if(err < 0) {
         fprintf(stderr, "Error initing palette (retval = %d)\n", err);
         return 1;
     }
+
+    // Called after init_colour_palette because that needs to have a
+    // timeout on getch() to determine whether the query worked.
+    nodelay(stdscr, true);
 
     //Init pipes. Use predetermined initial state, if any.
     pipes = malloc(num_pipes * sizeof(struct pipe));
@@ -145,6 +151,10 @@ int main(int argc, char **argv){
 
     curs_set(1);
     endwin();
+
+    restore_colors(&backup);
+    free_colors(&backup);
+
     free(pipes);
     palette_destroy(&palette);
     return 0;

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -25,7 +25,7 @@
 
 void interrupt_signal(int param);
 void parse_options(int argc, char **argv);
-static void find_num_colours(int argc, char **argv);
+static void find_num_colors(int argc, char **argv);
 float parse_float_opt(const char *optname);
 int parse_int_opt(const char *optname);
 noreturn void die(void);
@@ -46,7 +46,7 @@ const char *usage =
     "    -r, --prob=N    Probability of changing direction.(Default: 0.1   )\n"
     "    -i, --init=N    Initial state (0,1,2,3 => R,D,L,U)(Default: random)\n"
     "    -c, --color=C   Add color C (in RRGGBB hexadecimal) to palette.\n"
-    "    --backup-colors Backup colours and restore when exiting.\n"
+    "    --backup-colors Backup colors and restore when exiting.\n"
     "    -h, --help      This help message.\n";
 
 static struct option opts[] = {
@@ -92,8 +92,8 @@ char pipe_char_buf[CHAR_BUF_SZ];
 // Colour information stored here.
 struct palette palette;
 // Colours set by parse_options by the "-c" flag
-int *custom_colours = NULL;
-size_t num_custom_colours = 0;
+int *custom_colors = NULL;
+size_t num_custom_colors = 0;
 
 // Keep a separate pointer because this is optional.
 struct color_backup backup;
@@ -142,15 +142,15 @@ int main(int argc, char **argv){
     setbuf(stdout, NULL);
     getmaxyx(stdscr, screen_height, screen_width);
 
-    int err = init_colour_palette(
-            custom_colours, num_custom_colours,
+    int err = init_color_palette(
+            custom_colors, num_custom_colors,
             &palette, backup_ptr);
     if(err < 0) {
         fprintf(stderr, "Error initing palette (retval = %d)\n", err);
         goto cleanup;
     }
 
-    // Called after init_colour_palette because that needs to have a
+    // Called after init_color_palette because that needs to have a
     // timeout on getch() to determine whether the query worked.
     nodelay(stdscr, true);
 
@@ -159,7 +159,7 @@ int main(int argc, char **argv){
     for(unsigned int i=0; i<num_pipes;i++) {
         init_pipe(&pipes[i], &palette, initial_state,
             screen_width, screen_height);
-        random_pipe_colour(&pipes[i], &palette);
+        random_pipe_color(&pipes[i], &palette);
     }
 
     animate(fps, render, &screen_width, &screen_height, &interrupted, NULL);
@@ -173,7 +173,7 @@ cleanup:
         free_colors(backup_ptr);
     }
 
-    free(custom_colours);
+    free(custom_colors);
     free(pipes);
     palette_destroy(&palette);
     return 0;
@@ -183,7 +183,7 @@ void render(unsigned int width, unsigned int height, void *data){
     for(size_t i=0; i<num_pipes && !interrupted; i++){
         move_pipe(&pipes[i]);
         if(wrap_pipe(&pipes[i], width, height))
-            random_pipe_colour(&pipes[i], &palette);
+            random_pipe_color(&pipes[i], &palette);
 
         char old_state = pipes[i].state;
         if(should_flip_state(&pipes[i], min_len, prob)){
@@ -227,18 +227,18 @@ float parse_float_opt(const char *optname){
     return f_res;
 }
 
-void find_num_colours(int argc, char **argv) {
+void find_num_colors(int argc, char **argv) {
     opterr = 0;
-    // First work out how many colours were specified on the command line
+    // First work out how many colors were specified on the command line
     int c;
     while((c = getopt_long(argc, argv, "c:", opts, NULL)) != -1) {
         if(c == 'c')
-            num_custom_colours++;
+            num_custom_colors++;
     }
-    if(num_custom_colours > 0) {
-        custom_colours = malloc(sizeof(*custom_colours) * num_custom_colours);
-        if(!custom_colours) {
-            perror("Error allocating memory for colour palette.");
+    if(num_custom_colors > 0) {
+        custom_colors = malloc(sizeof(*custom_colors) * num_custom_colors);
+        if(!custom_colors) {
+            perror("Error allocating memory for color palette.");
             exit(1);
         }
     }
@@ -250,10 +250,10 @@ void parse_options(int argc, char **argv){
     opterr = 1;
     int c;
 
-    find_num_colours(argc, argv);
-    // Current colour (`-c`) and index into `custom_colours`
-    size_t colour_index = 0;
-    int colour = 0;
+    find_num_colors(argc, argv);
+    // Current color (`-c`) and index into `custom_colors`
+    size_t color_index = 0;
+    int color = 0;
 
     optind = 0;
     while((c = getopt_long(argc, argv, "p:f:al:r:i:c:h", opts, NULL)) != -1){
@@ -293,11 +293,11 @@ void parse_options(int argc, char **argv){
                 backup_ptr = &backup;
                 break;
             case 'c':
-                if(sscanf(optarg, "%x", &colour) != 1) {
-                    fprintf(stderr, "Invalid colour '%s'\n", optarg);
+                if(sscanf(optarg, "%x", &color) != 1) {
+                    fprintf(stderr, "Invalid color '%s'\n", optarg);
                     die();
                 }
-                custom_colours[colour_index++] = colour;
+                custom_colors[color_index++] = color;
                 break;
             case 'h':
                 usage_msg(0);

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -1,7 +1,9 @@
 #include <config.h>
 
+#include <inttypes.h>
 #include <langinfo.h>
 #include <string.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -92,7 +94,7 @@ char pipe_char_buf[CHAR_BUF_SZ];
 // Colour information stored here.
 struct palette palette;
 // Colours set by parse_options by the "-c" flag
-int *custom_colors = NULL;
+uint32_t *custom_colors = NULL;
 size_t num_custom_colors = 0;
 
 // Keep a separate pointer because this is optional.
@@ -253,7 +255,7 @@ void parse_options(int argc, char **argv){
     find_num_colors(argc, argv);
     // Current color (`-c`) and index into `custom_colors`
     size_t color_index = 0;
-    int color = 0;
+    uint32_t color = 0;
 
     optind = 0;
     while((c = getopt_long(argc, argv, "p:f:al:r:i:c:h", opts, NULL)) != -1){
@@ -293,7 +295,7 @@ void parse_options(int argc, char **argv){
                 backup_ptr = &backup;
                 break;
             case 'c':
-                if(sscanf(optarg, "%x", &color) != 1) {
+                if(sscanf(optarg, "%" SCNx32, &color) != 1) {
                     fprintf(stderr, "Invalid color '%s'\n", optarg);
                     die();
                 }

--- a/src/err.c
+++ b/src/err.c
@@ -1,0 +1,93 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "err.h"
+
+// Maximum size of an error message. Any messages longer than this are just
+// truncated: I don't want to handle errors within errors.
+#define ERR_BUF_SZ 256
+
+// Buffer containing an error message
+static char ERR_BUF[ERR_BUF_SZ];
+// Offset into ERR_BUF: new messages should be appended after this.
+static size_t ERR_OFFSET = 0;
+
+/** These correspond to the numbers PIPES_C_ERRORS multipled by -1. */
+static const char *PIPES_C_ERROR_STRINGS[] = {
+    "Success. If you see this an error message, please raise an issue!",
+
+    // Parameter 1: Detailed message indicating ncurses error
+    "An error was encountered in ncurses: %s.",
+
+    // Parameter 1: Number of colors in the palette
+    // Parameter 2: Number of available colors.
+    "Too many colors for the terminal to handle were given in the palette."
+        " %d colors were specified, but only %d are available.",
+
+    "A color palette was supplied, but the terminal cannot redefine colors.",
+    "A color palette was supplied, but the terminal cannot use color.",
+    "Error allocating memory.",
+    "Terminal did not reply to query.",
+    "Buffer (%d items) too small: tried to insert %d items.",
+    "Error encountered calling standard library function: %s",
+    "An error occurred when calling iconv."
+};
+
+static void err_provenance(const char *file, int line, const char *function);
+
+/// Write prefix containing file name, line and function.
+static void err_provenance(const char *file, int line, const char *function) {
+    ERR_OFFSET += snprintf(ERR_BUF + ERR_OFFSET,
+            ERR_BUF_SZ - ERR_OFFSET,
+            "[%s:%d (%s)] ", file, line, function);
+}
+
+
+/** Store message in buffer. */
+void set_error_(const char *file, int line, const char *function,
+        cpipes_errno err_num, ...) {
+    err_provenance(file, line, function);
+
+    va_list extra_args;
+    va_start(extra_args, err_num);
+    ERR_OFFSET += vsnprintf(
+            ERR_BUF + ERR_OFFSET, ERR_BUF_SZ - ERR_OFFSET,
+            PIPES_C_ERROR_STRINGS[-err_num], extra_args);
+    va_end(extra_args);
+
+    // Always terminate with a nul, even if snprintf didn't allow anything to
+    // actually be appended.
+    ERR_BUF[ERR_BUF_SZ - 1] = '\0';
+}
+
+void add_error_info_(const char *file, int line, const char *function,
+        const char *fmt, ...) {
+    ERR_OFFSET += snprintf(
+            ERR_BUF + ERR_OFFSET,
+            ERR_BUF_SZ - ERR_OFFSET,
+            "%s", "\n");
+    err_provenance(file, line, function);
+
+    va_list extra_args;
+    va_start(extra_args, fmt);
+    ERR_OFFSET += vsnprintf(
+            ERR_BUF + ERR_OFFSET, ERR_BUF_SZ - ERR_OFFSET,
+            fmt, extra_args);
+    va_end(extra_args);
+}
+
+/** Clear error buffer. */
+void clear_error(void) {
+    ERR_BUF[0] = '\0';
+    ERR_OFFSET = 0;
+}
+
+
+void print_error(void) {
+    fprintf(stderr, "%s\n", ERR_BUF);
+}
+
+const char *string_error(void) {
+    return ERR_BUF;
+}

--- a/src/err.h
+++ b/src/err.h
@@ -1,0 +1,39 @@
+#ifndef ERR_H_
+#define ERR_H_
+
+/** Error numbers returned by various functions. */
+enum PIPES_C_ERRORS {
+    ERR_CURSES_ERR = -1,
+    ERR_TOO_MANY_COLORS = -2,
+    ERR_CANNOT_CHANGE_COLOR = -3,
+    ERR_NO_COLOR = -4,
+    ERR_OUT_OF_MEMORY = -5,
+    ERR_QUERY_UNSUPPORTED = -6,
+    ERR_BUFFER_TOO_SMALL = -7,
+    ERR_C_ERROR = -8,
+    ERR_ICONV_ERROR = -9
+};
+
+/** This is to make it more obvious which functions return an error and which
+ * return a meaningful int. */
+typedef enum PIPES_C_ERRORS cpipes_errno;
+
+#define set_error(...) set_error_( \
+        __FILE__, __LINE__, __func__, \
+        __VA_ARGS__)
+
+#define add_error_info(...) add_error_info_( \
+        __FILE__, __LINE__, __func__, \
+        __VA_ARGS__)
+
+/** Called by set_error macro with __FILE__, __LINE__ and __func__ */
+void set_error_(const char *file, int line, const char *function,
+        cpipes_errno err_num, ...);
+void add_error_info_(const char *file, int line, const char *function,
+        const char *fmt, ...);
+void clear_error(void);
+void print_error(void);
+const char *string_error(void);
+
+#endif /* ERR_H_ */
+

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -311,7 +311,7 @@ void init_pipe(struct pipe *pipe, struct palette *palette,
         pipe->state = randrange(0, 4);
     else
         pipe->state = initial_state;
-    random_pipe_colour(pipe, palette);
+    random_pipe_color(pipe, palette);
     pipe->length = 0;
     pipe->x = randrange(0, width / colwidth) * colwidth;
     pipe->y = randrange(0, height / colwidth) * colwidth;
@@ -347,8 +347,8 @@ bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height){
     return false;
 }
 
-void random_pipe_colour(struct pipe *pipe, struct palette *palette){
-    pipe->colour = palette->colors[randrange(0, palette->num_colors)];
+void random_pipe_color(struct pipe *pipe, struct palette *palette){
+    pipe->color = palette->colors[randrange(0, palette->num_colors)];
 }
 
 char flip_pipe_state(struct pipe *pipe){

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -10,6 +10,7 @@
 #include <wchar.h>
 #include "pipe.h"
 #include "util.h"
+#include "render.h"
 
 /* This file contains functions for managing the initialisation and movement of
  * a pipe.
@@ -299,7 +300,8 @@ int multicolumn_adjust(char **continuation) {
  * function makes sure to only assign initial positions at full-character
  * boundaries.
  */
-void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
+void init_pipe(struct pipe *pipe, struct palette *palette,
+        int initial_state,
         unsigned int width, unsigned int height){
     // Multicolumn chars shouldn't be placed off the end of the screen
     size_t colwidth = max(states[0][0], -states[2][0]);
@@ -309,7 +311,7 @@ void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
         pipe->state = randrange(0, 4);
     else
         pipe->state = initial_state;
-    pipe->colour = randrange(0, ncolours);
+    random_pipe_colour(pipe, palette);
     pipe->length = 0;
     pipe->x = randrange(0, width / colwidth) * colwidth;
     pipe->y = randrange(0, height / colwidth) * colwidth;
@@ -345,8 +347,8 @@ bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height){
     return false;
 }
 
-void random_pipe_colour(struct pipe *pipe, int ncolours){
-    pipe->colour = randrange(0, ncolours);
+void random_pipe_colour(struct pipe *pipe, struct palette *palette){
+    pipe->colour = palette->colors[randrange(0, palette->num_colors)];
 }
 
 char flip_pipe_state(struct pipe *pipe){

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include "err.h"
 
 //States and transition characters
 extern char states[][2];
@@ -44,14 +45,14 @@ char pipe_char(struct pipe *p, char old_state);
 
 const char * transition_char(char **list, int row, int col);
 
-int locale_to_utf8(char *locale_bytes, char *utf8_bytes,
+cpipes_errno locale_to_utf8(char *locale_bytes, char *utf8_bytes,
         const char *from_charset, size_t buflen);
-int utf8_to_locale(
+cpipes_errno utf8_to_locale(
         char *utf8_chars,
         char *out_chars, size_t buflen,
         const char *to_charset);
-int assign_matrices(char *pipe_chars,
+void assign_matrices(char *pipe_chars,
         char **transition, char **continuation);
-int multicolumn_adjust(char **continuation);
+cpipes_errno multicolumn_adjust(char **continuation);
 
 #endif //PIPE_H_

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -19,7 +19,7 @@ extern char states[][2];
 //Represents a pipe
 struct pipe {
     unsigned char state;
-    unsigned int colour;
+    unsigned int color;
     unsigned short length;
     int x, y;
 };
@@ -38,7 +38,7 @@ void init_pipe(struct pipe *pipe, struct palette *palette,
 void move_pipe(struct pipe *pipe);
 bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height);
 char flip_pipe_state(struct pipe *pipe);
-void random_pipe_colour(struct pipe *pipe, struct palette *palette);
+void random_pipe_color(struct pipe *pipe, struct palette *palette);
 bool should_flip_state(struct pipe *p, int min_len, float prob);
 char pipe_char(struct pipe *p, char old_state);
 

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -19,7 +19,7 @@ extern char states[][2];
 //Represents a pipe
 struct pipe {
     unsigned char state;
-    unsigned short colour;
+    unsigned int colour;
     unsigned short length;
     int x, y;
 };
@@ -30,14 +30,15 @@ enum DIRECTIONS {
     LEFT = 2,
     UP = 3
 };
+struct palette;
 
-
-void init_pipe(struct pipe *pipe, int ncolours, int initial_state,
+void init_pipe(struct pipe *pipe, struct palette *palette,
+        int initial_state,
         unsigned int width, unsigned int height);
 void move_pipe(struct pipe *pipe);
 bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height);
 char flip_pipe_state(struct pipe *pipe);
-void random_pipe_colour(struct pipe *pipe, int ncolours);
+void random_pipe_colour(struct pipe *pipe, struct palette *palette);
 bool should_flip_state(struct pipe *p, int min_len, float prob);
 char pipe_char(struct pipe *p, char old_state);
 

--- a/src/render.c
+++ b/src/render.c
@@ -32,9 +32,9 @@ static cpipes_errno query_terminal(const char *escape, char *buffer, int bufsz);
 
 // Cribbed straight from Wikipedia :)
 int hsl2rgb(float hue, float sat, float light) {
-    float chroma = (1.0f - fabsf(2*light - 1)) * sat;
+    float chroma = (1.0f - fabsf(2.0f*light - 1)) * sat;
     float hue_segment = hue / 60;
-    float cpt2 = chroma * (1 - fabsf(fmod(hue_segment, 2) - 1));
+    float cpt2 = chroma * (1 - fabsf(fmodf(hue_segment, 2.0f) - 1));
     float r, g, b;
     switch((int)hue_segment){
         case 0: r = chroma; g = cpt2  ; b = 0     ; break;

--- a/src/render.c
+++ b/src/render.c
@@ -59,12 +59,16 @@ int hsl2rgb(float hue, float sat, float light) {
 // Check whether this terminal has the RGB capability (direct colors).
 // This is adapted from `parse_rgb.h` header with the ncurses test programs.
 bool have_direct_colors(void) {
-    if (tigetflag("RGB") > 0) {
+    // Required because terminfo on mac requires a non-const name
+    char rgbcap[4];
+    strcpy(rgbcap, "RGB");
+
+    if (tigetflag(rgbcap) > 0) {
         return true;
-    } else if (tigetnum("RGB") > 0) {
+    } else if (tigetnum(rgbcap) > 0) {
         return true;
     } else {
-        char *strval = tigetstr("RGB");
+        char *strval = tigetstr(rgbcap);
         if(strval != (char *) -1 && strval)
             return true;
     }

--- a/src/render.c
+++ b/src/render.c
@@ -84,7 +84,7 @@ size_t palette_size(void) {
     // 8 colors.
     int max_pipe_colors = min(COLORS, COLOR_PAIRS);
 
-#if !HAVE_ALLOC_PAIR
+#if !defined HAVE_ALLOC_PAIR
     // On systems that do not support alloc_pair, the max. number of pairs
     // that can actually be used is 32767, because that is the limit of
     // the positive numbers in a 16-bit unsigned short. Apparently this
@@ -92,7 +92,7 @@ size_t palette_size(void) {
     max_pipe_colors = min(max_pipe_colors, 32767);
 #endif
 
-#if !HAVE_EXTENDED_COLOR
+#if !defined HAVE_EXTENDED_COLOR
     // Similarly, if we cannot call `init_extended_color`, then we cannot
     // set more than 32767 colors, no matter how many pairs we have.
     max_pipe_colors = min(max_pipe_colors, 32767);
@@ -255,10 +255,10 @@ void palette_destroy(struct palette *palette) {
 int set_pair(int pair_index, int fg, int bg) {
     int retval;
     int alloced_index = pair_index;
-#if HAVE_ALLOC_PAIR
+#if defined HAVE_ALLOC_PAIR
     retval = alloc_pair(fg, bg);
     alloced_index = retval;
-#elif HAVE_EXTENDED_COLOR
+#elif defined HAVE_EXTENDED_COLOR
     retval = init_extended_pair(pair_index, fg, bg);
 #else
     retval = init_pair(pair_index, fg, bg);
@@ -285,7 +285,7 @@ int set_color_pair_indirect(int color_index, uint32_t color) {
     int b = ((color      ) & 0xFF) * 1000 / 255;
 
     int retval;
-#if HAVE_EXTENDED_COLOR
+#if defined HAVE_EXTENDED_COLOR
     retval = init_extended_color(color_index, r, g, b);
 #else
     retval = init_color(color_index, r, g, b);

--- a/src/render.c
+++ b/src/render.c
@@ -31,9 +31,9 @@ static int query_terminal(const char *escape, char *buffer, int bufsz);
 
 // Cribbed straight from Wikipedia :)
 int hsl2rgb(float hue, float sat, float light) {
-    float chroma = (1.0f - fabs(2*light - 1)) * sat;
+    float chroma = (1.0f - fabsf(2*light - 1)) * sat;
     float hue_segment = hue / 60;
-    float cpt2 = chroma * (1 - fabs(fmod(hue_segment, 2) - 1));
+    float cpt2 = chroma * (1 - fabsf(fmod(hue_segment, 2) - 1));
     float r, g, b;
     switch((int)hue_segment){
         case 0: r = chroma; g = cpt2  ; b = 0     ; break;

--- a/src/render.c
+++ b/src/render.c
@@ -420,9 +420,11 @@ cpipes_errno create_color_backup(size_t num_colors,
     return 0;
 
 error:
-    for(i = i - 1; i > 0; i--)
-        free(escape_codes[i]);
+    while(i > 0)
+        free(escape_codes[--i]);
     free(escape_codes);
+    backup->escape_codes = NULL;
+    backup->num_colors = 0;
     return err;
 }
 

--- a/src/render.c
+++ b/src/render.c
@@ -15,11 +15,11 @@
 
 #define ESCAPE_CODE_SIZE 256
 
-// Number of reserved pairs in indirect mode (just colour pair 0)
+// Number of reserved pairs in indirect mode (just color pair 0)
 #define RESERVED_INDIRECT_PAIRS 1
 
 static int hsl2rgb(float hue, float sat, float light);
-static bool have_direct_colours(void);
+static bool have_direct_colors(void);
 static int set_color_pair_direct(int color_index, int color);
 static int set_color_pair_indirect(int color_index, int color);
 static int set_pair(int pair_index, int fg, int bg);
@@ -55,7 +55,7 @@ int hsl2rgb(float hue, float sat, float light) {
 
 // Check whether this terminal has the RGB capability (direct colors).
 // This is adapted from `parse_rgb.h` header with the ncurses test programs.
-bool have_direct_colours(void) {
+bool have_direct_colors(void) {
     if (tigetflag("RGB") > 0) {
         return true;
     } else if (tigetnum("RGB") > 0) {
@@ -70,15 +70,15 @@ bool have_direct_colours(void) {
 
 /// Returns the effective size of the palette that we can use.
 int palette_size(void) {
-    bool direct = have_direct_colours();
+    bool direct = have_direct_colors();
 
-    // On terminals that support direct colour, COLORS can be greater than
-    // COLOR_PAIRS. We can only display `COLOR_PAIRS` different colours,
+    // On terminals that support direct color, COLORS can be greater than
+    // COLOR_PAIRS. We can only display `COLOR_PAIRS` different colors,
     // though, so that is the size of our palette.
     //
-    // Note that for terminals that do not support direct colour, we reduce the
-    // possible number of colours by 8, because we should not alter the default
-    // 8 colours.
+    // Note that for terminals that do not support direct color, we reduce the
+    // possible number of colors by 8, because we should not alter the default
+    // 8 colors.
     int max_pipe_colors = min(COLORS, COLOR_PAIRS);
 
 #if !HAVE_ALLOC_PAIR
@@ -91,17 +91,17 @@ int palette_size(void) {
 
 #if !HAVE_EXTENDED_COLOR
     // Similarly, if we cannot call `init_extended_color`, then we cannot
-    // set more than 32767 colours, no matter how many pairs we have.
+    // set more than 32767 colors, no matter how many pairs we have.
     max_pipe_colors = min(max_pipe_colors, 32767);
 #endif
 
-    // If we *can* change colours, we remove 1 because we can't write to colour
-    // pair 0. If we can't change colours, the we should use the full colour
+    // If we *can* change colors, we remove 1 because we can't write to color
+    // pair 0. If we can't change colors, the we should use the full color
     // range, minus one because that one will be the background.
     //
     // If we're using direct colors, we never actually
     // call `init_color` or `init_extended_color`, so we don't have to worry
-    // about preserving any colours.
+    // about preserving any colors.
     if(can_change_color() && !direct)
         max_pipe_colors -= RESERVED_INDIRECT_PAIRS;
     else if(!can_change_color())
@@ -113,56 +113,56 @@ int palette_size(void) {
 /**
  * If `colors` is not `NULL`, then the color palette is initialised to each of
  * the `num_colors` elements in `colors`. Colors are interpreted as `0xRRGGBB`.
- * Each colour is assigned a palette ID (color pair number, in curses-speak),
- * which are returned in order in `palette->colors`. The number of colours in
+ * Each color is assigned a palette ID (color pair number, in curses-speak),
+ * which are returned in order in `palette->colors`. The number of colors in
  * the palette is returned in `palette->num_colors`.
  *
  * In the special case that `palette` is non-NULL, but `num_colors` is zero,
  * `palette` is set to the default palette.  The default color palette is a
- * sweep of HSL space with maximum saturation and lightness. Each colour is
+ * sweep of HSL space with maximum saturation and lightness. Each color is
  * evenly spaced in hue space.
  *
- * The colour palette should be freed using `palette_destroy` when it is no
+ * The color palette should be freed using `palette_destroy` when it is no
  * longer needed.
  *
  * If `backup` is non-`NULL`, then the terminal is queried for the escape
- * codes used to reset the original colours. These are stored in `backup`.
+ * codes used to reset the original colors. These are stored in `backup`.
  *
  * This function will return 0 on success, and a negative value on failure. An
  * error is printed to standard output upon error. Possible error modes:
  *
- * - Specifying more than `COLOR_PAIRS` colours (return `ERR_TOO_MANY_COLORS`).
+ * - Specifying more than `COLOR_PAIRS` colors (return `ERR_TOO_MANY_COLORS`).
  *
- * - Specifying more than 32767 colours on a system that does not support
+ * - Specifying more than 32767 colors on a system that does not support
  *   `alloc_pair`. On systems without `alloc_pair`, the classic `init_pair`
  *   interface must be used, which only supports as many numbers as can fit
  *   in the positive part of a signed 16-bit short (return
  *   `ERR_TOO_MANY_COLORS`).
  *
- * - Specifying colours in a terminal that does not support redefining colours.
+ * - Specifying colors in a terminal that does not support redefining colors.
  *   That is, setting `colors` to a non-`NULL` value when `can_change_color` is
  *   false results in an error (return `ERR_CANNOT_CHANGE_COLOR`). If the
  *   default palette is used, there is no error; instead, the default palette
  *   is the hardcoded terminal palette.
  *
- * - If colours are not supported (return `ERR_NO_COLOR`).
+ * - If colors are not supported (return `ERR_NO_COLOR`).
  *
- * - If an error is encountered by ncurses when allocating colours or colour
+ * - If an error is encountered by ncurses when allocating colors or color
  *   pairs, `ERR_CURSES_ERR` is returned.
  *
  * - Alternatively, `ERR_OUT_OF_MEMORY` may be returned if allocation of the
- *   colour palette fails.
+ *   color palette fails.
  */
-int init_colour_palette(int *colors, int num_colors,
+int init_color_palette(int *colors, int num_colors,
         struct palette *palette, struct color_backup *backup) {
     if(!has_colors())
         return ERR_NO_COLOR;
 
     // With direct colors, we set the color directly in the pair
     // e.g. init_extended_pair(i, COLOR_BLACK, rgb);
-    bool direct = have_direct_colours();
+    bool direct = have_direct_colors();
 
-    // If we aren't using direct colours and we can't change colours to match
+    // If we aren't using direct colors and we can't change colors to match
     // the specified palette, that is an error.
     if(!direct && (colors && !can_change_color()))
         return ERR_CANNOT_CHANGE_COLOR;
@@ -177,7 +177,7 @@ int init_colour_palette(int *colors, int num_colors,
         max_pipe_colors = num_colors;
     }
 
-    // Make backup of colours by querying terminal.
+    // Make backup of colors by querying terminal.
     if(backup) {
         if(!direct) {
             int err = create_color_backup(max_pipe_colors, backup);
@@ -196,12 +196,12 @@ int init_colour_palette(int *colors, int num_colors,
 
     // Set palette, either to the value specified in colors or to an HSL sweep.
     // Note that calls to init_color or init_extended_color must have the
-    // colour index increased by 1 to avoid writing to colour pair 0.
+    // color index increased by 1 to avoid writing to color pair 0.
     for(int i=0; i < max_pipe_colors; i++) {
         if(!can_change_color() && !direct){
-            // Just use the colours in the default palette if we can't change
-            // colours. The colour is `i + 1` because we don't want to use
-            // the backgroudn colour for the foreground.
+            // Just use the colors in the default palette if we can't change
+            // colors. The color is `i + 1` because we don't want to use
+            // the backgroudn color for the foreground.
             palette->colors[i] = set_pair(i, i + 1, COLOR_BLACK);
         }else{
             int color;
@@ -233,7 +233,7 @@ void palette_destroy(struct palette *palette) {
 
 
 /**
- * Set the colour pair `pair_index` to the given colour in as version agnostic
+ * Set the color pair `pair_index` to the given color in as version agnostic
  * a way as possible. If `alloc_pair` is available, then `pair_index` is
  * ignored; otherwise it is passed as the pair ID to `init_pair`.
  *
@@ -256,7 +256,7 @@ int set_pair(int pair_index, int fg, int bg) {
 }
 
 /**
- * Set the foreground of a colour pair to `color` (in `0xRRGGBB` form).
+ * Set the foreground of a color pair to `color` (in `0xRRGGBB` form).
  * The index `color_index` will be used as the pair index if
  * `alloc_pair` is not supported: otherwise, the index returned can be
  * unrelated.
@@ -264,7 +264,7 @@ int set_pair(int pair_index, int fg, int bg) {
  * Returns the ID of the new pair, or `ERR_CURSES_ERR` on error.
  *
  * Note that the color should be zero-indexed. This function internally
- * adds 1 to it to avoid overwriting any of the default colours.
+ * adds 1 to it to avoid overwriting any of the default colors.
  */
 int set_color_pair_indirect(int color_index, int color) {
     int r = ((color >> 16) & 0xFF) * 1000 / 255;
@@ -285,7 +285,7 @@ int set_color_pair_indirect(int color_index, int color) {
 }
 
 /**
- * Set the foreground colour of a pair to `color`, given in the form
+ * Set the foreground color of a pair to `color`, given in the form
  * `0xRRGGBB`. The index of the pair will be `color_index` if `alloc_pair`
  * is not supported; it can be arbitrary otherwise.
  */
@@ -335,9 +335,9 @@ void animate(int fps, anim_function renderer,
 
 /**
  * Some terminals (looking at you, urxvt), do not properly reset the
- * terminal colours when ncurses exits. Some terminals support querying
- * the current terminal colours (via OSC 4 ?), which should allow us to
- * reset the colours later.
+ * terminal colors when ncurses exits. Some terminals support querying
+ * the current terminal colors (via OSC 4 ?), which should allow us to
+ * reset the colors later.
  */
 int create_color_backup(int num_colors, struct color_backup *backup){
     int err = 0;
@@ -354,7 +354,7 @@ int create_color_backup(int num_colors, struct color_backup *backup){
     int i;
     for(i=0; i < num_colors; i++) {
 
-        // Query the value of colour "i". If the terminal understands the
+        // Query the value of color "i". If the terminal understands the
         // escape sequence, it will write the response to the standard input of
         // the program, terminating with a BEL.
         sprintf(buffer, "\033]4;%d;?\007", i + 1);
@@ -366,7 +366,7 @@ int create_color_backup(int num_colors, struct color_backup *backup){
         }
 
         // xterm and urxvt give different responses to the query. Xterm is
-        // sensible, and includes the colour index in the response
+        // sensible, and includes the color index in the response
         // (\033]4;i;rgb:), but urxvt doesn't (\033]4;rgb:).
         // We get around this by explicitly inserting the index here if it
         // is not present.
@@ -416,7 +416,7 @@ void restore_colors(struct color_backup *backup) {
     }
 }
 
-/** Free the list of escape codes used for restoring colours. */
+/** Free the list of escape codes used for restoring colors. */
 void free_colors(struct color_backup *backup) {
     for(int i=0; i < backup->num_colors; i++) {
         free(backup->escape_codes[i]);
@@ -450,7 +450,7 @@ void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state){
 
     move(p->y, p->x);
-    attr_set(A_NORMAL, 1, &p->colour);
+    attr_set(A_NORMAL, 1, &p->color);
     if(old_state != new_state) {
         addstr(transition_char(trans, old_state, new_state));
     }else{

--- a/src/render.c
+++ b/src/render.c
@@ -1,22 +1,263 @@
 #include <config.h>
 
+#include <math.h>
 #include <time.h>
 #include <signal.h>
 #include <curses.h>
 #include <stdlib.h>
+#include <term.h>
 #include "render.h"
 #include "pipe.h"
+#include "util.h"
 
 #define NS 1000000000L //1ns
 
-void init_colours(void){
-    //Initialise colour pairs if we can.
-    if(has_colors()){
-        start_color();
-        for(short i=1; i < COLORS; i++){
-            init_pair(i, i, COLOR_BLACK);
+static int hsl2rgb(float hue, float sat, float light);
+static bool have_direct_colours(void);
+static int set_color_pair_direct(int color_index, int color);
+static int set_color_pair_indirect(int color_index, int color);
+static int set_pair(int pair_index, int fg, int bg);
+static int palette_size(void);
+
+// Cribbed straight from Wikipedia :)
+int hsl2rgb(float hue, float sat, float light) {
+    float chroma = (1.0f - fabs(2*light - 1)) * sat;
+    float hue_segment = hue / 60;
+    float cpt2 = chroma * (1 - fabs(fmod(hue_segment, 2) - 1));
+    float r, g, b;
+    switch((int)hue_segment){
+        case 0: r = chroma; g = cpt2  ; b = 0     ; break;
+        case 1: r = cpt2  ; g = chroma; b = 0     ; break;
+        case 2: r = 0     ; g = chroma; b = cpt2  ; break;
+        case 3: r = 0     ; g = cpt2  ; b = chroma; break;
+        case 4: r = cpt2  ; g = 0     ; b = chroma; break;
+        case 5: r = chroma; g = 0     ; b = cpt2  ; break;
+        default: r = 0; g = 0; b = 0;
+    }
+    float offset = light - chroma/2;
+    r += offset;
+    g += offset;
+    b += offset;
+
+    int ir = (int)(r * 255);
+    int ig = (int)(g * 255);
+    int ib = (int)(b * 255);
+    return (ir << 16) | (ig << 8) | ib;
+}
+
+// Check whether this terminal has the RGB capability (direct colors).
+// This is adapted from `parse_rgb.h` header with the ncurses test programs.
+bool have_direct_colours(void) {
+    if (tigetflag("RGB") > 0) {
+        return true;
+    } else if (tigetnum("RGB") > 0) {
+        return true;
+    } else {
+        char *strval = tigetstr("RGB");
+        if(strval != (char *) -1 && strval)
+            return true;
+    }
+    return false;
+}
+
+/// Returns the effective size of the palette that we can use.
+int palette_size(void) {
+    bool direct = have_direct_colours();
+
+    // On terminals that support direct colour, COLORS can be greater than
+    // COLOR_PAIRS. We can only display `COLOR_PAIRS` different colours,
+    // though, so that is the size of our palette.
+    //
+    // Note that for terminals that do not support direct colour, we reduce the
+    // possible number of colours by 8, because we should not alter the default
+    // 8 colours.
+    int max_pipe_colors = min(COLORS, COLOR_PAIRS);
+
+#if !HAVE_ALLOC_PAIR
+    // On systems that do not support alloc_pair, the max. number of pairs
+    // that can actually be used is 32767, because that is the limit of
+    // the positive numbers in a 16-bit unsigned short. Apparently this
+    // applies even with `init_extended_pair`.
+    max_pipe_colors = min(max_pipe_colors, 32767);
+#endif
+
+#if !HAVE_EXTENDED_COLOR
+    // Similarly, if we cannot call `init_extended_color`, then we cannot
+    // set more than 32767 colours, no matter how many pairs we have.
+    max_pipe_colors = min(max_pipe_colors, 32767);
+#endif
+
+    // If we *can* change colours, we remove 8 because we can't write to the
+    // default 8 colours. If we can't change colours, the we should use the
+    // full colour range, minus one because that one will be the backgorund.
+    //
+    // If we're using direct colors, we never actually
+    // call `init_color` or `init_extended_color`, so we don't have to worry
+    // about preserving the first 8 colours.
+    if(can_change_color() && !direct)
+        max_pipe_colors -= 8;
+    else if(!can_change_color())
+        max_pipe_colors -= 1;
+
+    return max_pipe_colors;
+}
+
+/**
+ * If `colors` is not `NULL`, then the color palette is initialised to each of
+ * the `num_colors` elements in `colors`. Colors are interpreted as `0xRRGGBB`.
+ * Each colour is assigned a palette ID (color pair number, in curses-speak),
+ * which are returned in order in `palette->colors`. The number of colours in
+ * the palette is returned in `palette->num_colors`.
+ *
+ * In the special case that `palette` is non-NULL, but `num_colors` is zero,
+ * `palette` is set to the default palette.  The default color palette is a
+ * sweep of HSL space with maximum saturation and lightness. Each colour is
+ * evenly spaced in hue space.
+ *
+ * The colour palette should be freed using `palette_destroy` when it is no
+ * longer needed.
+ *
+ * This function will return 0 on success, and a negative value on failure. An
+ * error is printed to standard output upon error. Possible error modes:
+ *
+ * - Specifying more than `COLOR_PAIRS` colours (return `ERR_TOO_MANY_COLORS`).
+ *
+ * - Specifying more than 32767 colours on a system that does not support
+ *   `alloc_pair`. On systems without `alloc_pair`, the classic `init_pair`
+ *   interface must be used, which only supports as many numbers as can fit
+ *   in the positive part of a signed 16-bit short (return
+ *   `ERR_TOO_MANY_COLORS`).
+ *
+ * - Specifying colours in a terminal that does not support redefining colours.
+ *   That is, setting `colors` to a non-`NULL` value when `can_change_color` is
+ *   false results in an error (return `ERR_CANNOT_CHANGE_COLOR`). If the
+ *   default palette is used, there is no error; instead, the default palette
+ *   is the hardcoded terminal palette.
+ *
+ * - If colours are not supported (return `ERR_NO_COLOR`).
+ *
+ * - If an error is encountered by ncurses when allocating colours or colour
+ *   pairs, `ERR_CURSES_ERR` is returned.
+ *
+ * - Alternatively, `ERR_OUT_OF_MEMORY` may be returned if allocation of the
+ *   colour palette fails.
+ */
+int init_colour_palette(int *colors, int num_colors, struct palette *palette) {
+    if(!has_colors())
+        return ERR_NO_COLOR;
+    if(colors && !can_change_color())
+        return ERR_CANNOT_CHANGE_COLOR;
+
+    start_color();
+
+    // With direct colors, we set the color directly in the pair
+    // e.g. init_extended_pair(i, COLOR_BLACK, rgb);
+    bool direct = have_direct_colours();
+    int max_pipe_colors = palette_size();
+
+    // Use supplied palette, if any.
+    if(colors) {
+        if(num_colors > max_pipe_colors)
+            return ERR_TOO_MANY_COLORS;
+        max_pipe_colors = num_colors;
+    }
+    palette->num_colors = max_pipe_colors;
+    palette->colors = malloc(sizeof(*palette->colors) * palette->num_colors);
+    if(!palette->colors)
+        return ERR_OUT_OF_MEMORY;
+
+    // Set palette, either to the value specified in colors or to an HSL sweep.
+    // Note that calls to init_color or init_extended_color must have the
+    // colour index increased by 8 to avoid writing to the default 8 colours.
+    for(int i=0; i < max_pipe_colors; i++) {
+        if(!can_change_color() && !direct){
+            palette->colors[i] = set_pair(i, i + 1, COLOR_BLACK);
+        }else{
+            int color;
+            if(colors)
+                color = colors[i];
+            else
+                color = hsl2rgb(((float) i) * 360 / max_pipe_colors, 1, 0.5);
+
+            int pair_index;
+            if(direct) {
+                pair_index = set_color_pair_direct(i, color);
+            }else{
+                pair_index = set_color_pair_indirect(i, color);
+            }
+            if(pair_index < 0)
+                return pair_index;
+            palette->colors[i] = pair_index;
         }
     }
+    return 0;
+}
+
+/// Free memory associated with color palette.
+void palette_destroy(struct palette *palette) {
+    free(palette->colors);
+}
+
+
+/**
+ * Set the colour pair `pair_index` to the given colour in as version agnostic
+ * a way as possible. If `alloc_pair` is available, then `pair_index` is
+ * ignored; otherwise it is passed as the pair ID to `init_pair`.
+ *
+ * Returns -1 on error, or the pair index
+ */
+int set_pair(int pair_index, int fg, int bg) {
+    int retval;
+    int alloced_index = pair_index;
+#if HAVE_ALLOC_PAIR
+    retval = alloc_pair(fg, bg);
+    alloced_index = retval;
+#elif HAVE_EXTENDED_COLOR
+    retval = init_extended_pair(pair_index, fg, bg);
+#else
+    retval = init_pair(pair_index, fg, bg);
+#endif
+    if(retval == ERR)
+        return retval;
+    return alloced_index;
+}
+
+/**
+ * Set the foreground of a colour pair to `color` (in `0xRRGGBB` form).
+ * The index `color_index` will be used as the pair index if
+ * `alloc_pair` is not supported: otherwise, the index returned can be
+ * unrelated.
+ *
+ * Returns the ID of the new pair, or `ERR_CURSES_ERR` on error.
+ *
+ * Note that the color should be zero-indexed. This function internally
+ * adds 8 to it to avoid overwriting any of the default colours.
+ */
+int set_color_pair_indirect(int color_index, int color) {
+    int r = ((color >> 16) & 0xFF) * 1000 / 255;
+    int g = ((color >>  8) & 0xFF) * 1000 / 255;
+    int b = ((color      ) & 0xFF) * 1000 / 255;
+
+    int retval;
+#if HAVE_EXTENDED_COLOR
+    retval = init_extended_color(color_index + 8, r, g, b);
+#else
+    retval = init_color(color_index + 8, r, g, b);
+#endif
+    // Error initing color
+    if(retval == ERR)
+        return ERR_CURSES_ERR;
+
+    return set_pair(color_index, color_index + 8, COLOR_BLACK);
+}
+
+/**
+ * Set the foreground colour of a pair to `color`, given in the form
+ * `0xRRGGBB`. The index of the pair will be `color_index` if `alloc_pair`
+ * is not supported; it can be arbitrary otherwise.
+ */
+int set_color_pair_direct(int color_index, int color) {
+    return set_pair(color_index, color, COLOR_BLACK);
 }
 
 void animate(int fps, anim_function renderer,
@@ -63,11 +304,11 @@ void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state){
 
     move(p->y, p->x);
-    attron(COLOR_PAIR(p->colour));
+    attr_set(A_NORMAL, 1, &p->colour);
     if(old_state != new_state) {
         addstr(transition_char(trans, old_state, new_state));
     }else{
         addstr(pipe_chars[old_state % 2]);
     }
-    attroff(COLOR_PAIR(p->colour));
+    attr_off(A_NORMAL, NULL);
 }

--- a/src/render.h
+++ b/src/render.h
@@ -4,15 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "pipe.h"
-
-enum COLOR_ERRS {
-    ERR_CURSES_ERR = -1,
-    ERR_TOO_MANY_COLORS = -2,
-    ERR_CANNOT_CHANGE_COLOR = -3,
-    ERR_NO_COLOR = -4,
-    ERR_OUT_OF_MEMORY = -5,
-    ERR_QUERY_UNSUPPORTED = -6
-};
+#include "err.h"
 
 struct palette {
     uint32_t *colors;
@@ -27,7 +19,7 @@ struct color_backup {
 typedef void (*anim_function)(unsigned int width, unsigned int height,
         void *data);
 
-int init_color_palette(uint32_t *colors, size_t num_colors,
+cpipes_errno init_color_palette(uint32_t *colors, size_t num_colors,
         struct palette *palette, struct color_backup *backup);
 
 void init_colors(void);
@@ -38,7 +30,8 @@ void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);
 
 void palette_destroy(struct palette *palette);
-int create_color_backup(size_t num_colors, struct color_backup *backup);
+cpipes_errno create_color_backup(size_t num_colors,
+        struct color_backup *backup);
 void restore_colors(struct color_backup *backup);
 void free_colors(struct color_backup *backup);
 

--- a/src/render.h
+++ b/src/render.h
@@ -25,10 +25,10 @@ struct color_backup {
 typedef void (*anim_function)(unsigned int width, unsigned int height,
         void *data);
 
-int init_colour_palette(int *colors, int num_colors,
+int init_color_palette(int *colors, int num_colors,
         struct palette *palette, struct color_backup *backup);
 
-void init_colours(void);
+void init_colors(void);
 void animate(int fps, anim_function renderer,
         unsigned int *width, unsigned int *height,
         volatile sig_atomic_t *interrupted, void *data);

--- a/src/render.h
+++ b/src/render.h
@@ -1,6 +1,8 @@
 #ifndef RENDER_H_
 #define RENDER_H_
 #include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
 #include "pipe.h"
 
 enum COLOR_ERRS {
@@ -13,19 +15,19 @@ enum COLOR_ERRS {
 };
 
 struct palette {
-    int *colors;
-    int num_colors;
+    uint32_t *colors;
+    size_t num_colors;
 };
 
 struct color_backup {
-    int num_colors;
+    size_t num_colors;
     char **escape_codes;
 };
 
 typedef void (*anim_function)(unsigned int width, unsigned int height,
         void *data);
 
-int init_color_palette(int *colors, int num_colors,
+int init_color_palette(uint32_t *colors, size_t num_colors,
         struct palette *palette, struct color_backup *backup);
 
 void init_colors(void);
@@ -36,7 +38,7 @@ void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);
 
 void palette_destroy(struct palette *palette);
-int create_color_backup(int num_colors, struct color_backup *backup);
+int create_color_backup(size_t num_colors, struct color_backup *backup);
 void restore_colors(struct color_backup *backup);
 void free_colors(struct color_backup *backup);
 

--- a/src/render.h
+++ b/src/render.h
@@ -1,9 +1,25 @@
 #ifndef RENDER_H_
 #define RENDER_H_
+#include <signal.h>
 #include "pipe.h"
+
+enum COLOR_ERRS {
+    ERR_CURSES_ERR = -1,
+    ERR_TOO_MANY_COLORS = -2,
+    ERR_CANNOT_CHANGE_COLOR = -3,
+    ERR_NO_COLOR = -4,
+    ERR_OUT_OF_MEMORY = -5
+};
+
+struct palette {
+    int *colors;
+    int num_colors;
+};
 
 typedef void (*anim_function)(unsigned int width, unsigned int height,
         void *data);
+
+int init_colour_palette(int *colors, int num_colors, struct palette *palette);
 
 void init_colours(void);
 void animate(int fps, anim_function renderer,
@@ -11,5 +27,9 @@ void animate(int fps, anim_function renderer,
         volatile sig_atomic_t *interrupted, void *data);
 void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);
+
+int * save_color_state(void);
+void restore_color_state(int *colors);
+void palette_destroy(struct palette *palette);
 
 #endif //RENDER_H_

--- a/src/render.h
+++ b/src/render.h
@@ -8,7 +8,8 @@ enum COLOR_ERRS {
     ERR_TOO_MANY_COLORS = -2,
     ERR_CANNOT_CHANGE_COLOR = -3,
     ERR_NO_COLOR = -4,
-    ERR_OUT_OF_MEMORY = -5
+    ERR_OUT_OF_MEMORY = -5,
+    ERR_QUERY_UNSUPPORTED = -6
 };
 
 struct palette {
@@ -16,10 +17,16 @@ struct palette {
     int num_colors;
 };
 
+struct color_backup {
+    int num_colors;
+    char **escape_codes;
+};
+
 typedef void (*anim_function)(unsigned int width, unsigned int height,
         void *data);
 
-int init_colour_palette(int *colors, int num_colors, struct palette *palette);
+int init_colour_palette(int *colors, int num_colors,
+        struct palette *palette, struct color_backup *backup);
 
 void init_colours(void);
 void animate(int fps, anim_function renderer,
@@ -28,8 +35,9 @@ void animate(int fps, anim_function renderer,
 void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);
 
-int * save_color_state(void);
-void restore_color_state(int *colors);
 void palette_destroy(struct palette *palette);
+int create_color_backup(int num_colors, struct color_backup *backup);
+void restore_colors(struct color_backup *backup);
+void free_colors(struct color_backup *backup);
 
 #endif //RENDER_H_

--- a/t/locale.c
+++ b/t/locale.c
@@ -5,16 +5,21 @@
 #include <string.h>
 
 #include "pipe.h"
+#include "err.h"
 /**
  * Check locale-encoding functions.
  */
-#define NUM_TESTS 29
+#define NUM_TESTS 30
 
 // TAP-producing ok() function
-static int testnum = 0;
+static int testnum = 1;
+static int failures = 0;
+
 static void ok(bool condition, const char* msg);
 static void ok(bool condition, const char* msg) {
     printf("%s %d - %s\n", condition ? "ok" : "not ok", testnum++, msg);
+    if(!condition)
+        failures++;
 }
 
 // These are the same in UTF8 and GB18030
@@ -28,7 +33,7 @@ const char *GB18030_BOX = "\xA9\xA5\xA9\xA7";
 const char *GB18030_BOX_SPLIT = "\xA9\xA5\0\xA9\xA7";
 
 // Assigned to by assign_matrices
-const char *test_pipe_chars = "1\0" "2\0" "3\0" "4\0" "5\0" "6";
+const char test_pipe_chars[] = "1\0" "2\0" "3\0" "4\0" "5\0" "6";
 char *transition[16];
 char *continuation[2];
 
@@ -48,10 +53,17 @@ int main(int argc, char **argv) {
         "ASCII UTF8 to UTF8 in 4 bytes: no error code.");
     ok(strcmp(out, UTF8_ASCII) == 0,
         "ASCII UTF8 to UTF8 copied correctly");
+    clear_error();
 
     r = locale_to_utf8(in, out, "UTF-8", 3);
-    ok(r == -1,
+    ok(r == ERR_BUFFER_TOO_SMALL,
         "ASCII UTF8 to UTF8 in 3 bytes: buffer too small.");
+
+    ok(strstr(string_error(), "Buffer (3 items) too small"),
+        "Error text contains buffer size.");
+    ok(strstr(string_error(), "tried to insert 4 items"),
+        "Error text contains inserted size.");
+    clear_error();
 
     // Identity conversion with higher bytes
     strcpy(in, UTF8_BOX);
@@ -60,10 +72,12 @@ int main(int argc, char **argv) {
         "Box UTF8 to UTF8 in 7 bytes: no error code.");
     ok(strcmp(out, UTF8_BOX) == 0,
         "Box UTF8 to UTF8 copied correctly.");
+    clear_error();
 
     r = locale_to_utf8(in, out, "UTF-8", 6);
-    ok(r == -1,
+    ok(r == ERR_BUFFER_TOO_SMALL,
         "Box UTF8 to UTF8 in 6 bytes: buffer too small.");
+    clear_error();
 
     // Convert GB18030 to UTF-8 with ASCII bytes (no change)
     strcpy(in, GB18030_ASCII);
@@ -72,10 +86,12 @@ int main(int argc, char **argv) {
         "ASCII GB18030 to UTF8 in 4 bytes: no error code.");
     ok(strcmp(out, UTF8_ASCII) == 0,
         "ASCII UTF8 to GB18030 copied correctly");
+    clear_error();
 
     r = locale_to_utf8(in, out, "GB18030", 3);
-    ok(r == -1,
+    ok(r == ERR_ICONV_ERROR,
         "ASCII GB18030 to UTF8 in 3 bytes: buffer too small.");
+    clear_error();
 
     // Convert GB18030 to UTF-8 with box-drawing chars
     strcpy(in, GB18030_BOX);
@@ -84,10 +100,12 @@ int main(int argc, char **argv) {
         "Box GB18030 to UTF8 in 7 bytes: no error code.");
     ok(strcmp(out, UTF8_BOX) == 0,
         "Box GB18030 to UTF8 copied correctly.");
+    clear_error();
 
     r = locale_to_utf8(in, out, "GB18030", 6);
-    ok(r == -1,
+    ok(r == ERR_ICONV_ERROR,
         "Box GB18030 to UTF8 in 6 bytes: buffer too small.");
+    clear_error();
 
     // Convert UTF-8 to GB18030 with ASCII bytes
     strcpy(in, UTF8_ASCII);
@@ -96,10 +114,12 @@ int main(int argc, char **argv) {
         "ASCII UTF8 to GB18030 in 6 bytes: no error code.");
     ok(memcmp(out, GB18030_ASCII_SPLIT, 6) == 0,
         "ASCII UTF8 to GB18030 copied correctly.");
+    clear_error();
 
     r = utf8_to_locale(in, out, 5, "GB18030");
-    ok(r == -1,
+    ok(r == ERR_BUFFER_TOO_SMALL,
         "ASCII UTF8 to GB18030 in 5 bytes: buffer too small.");
+    clear_error();
 
     // Convert UTF-8 to GB18030 with box-drawing bytes
     strcpy(in, UTF8_BOX);
@@ -108,15 +128,18 @@ int main(int argc, char **argv) {
         "Box UTF8 to GB18030 in 6 bytes: no error code.");
     ok(memcmp(out, GB18030_BOX_SPLIT, 6) == 0,
         "Box UTF8 to GB18030 copied correctly.");
+    clear_error();
 
     r = utf8_to_locale(in, out, 5, "GB18030");
-    ok(r == -1,
+    ok(r == ERR_ICONV_ERROR,
         "Box UTF8 to GB18030 in 5 bytes: buffer too small.");
+    clear_error();
 
     // Assign transition and continuation matrices
-    strcpy(in, test_pipe_chars);
-    r = assign_matrices(in, transition, continuation);
-    ok(r == 0, "No error assigning matrices.");
+    memcpy(in, test_pipe_chars, sizeof(test_pipe_chars));
+    in[sizeof(test_pipe_chars)] = '\0';
+
+    assign_matrices(in, transition, continuation);
 
     ok(!strcmp(continuation[0], "1"), "HORIZONTAL");
     ok(!strcmp(continuation[1], "2"), "VERTICAL");
@@ -132,5 +155,6 @@ int main(int argc, char **argv) {
 
     ok(!strcmp(transition[LEFT * 4 + DOWN], "6"), "LEFT / DOWN");
     ok(!strcmp(transition[UP * 4 + RIGHT], "6"), "UP / RIGHT");
-    return 0;
+    clear_error();
+    return (failures > 0) ? 1 : 0;
 }

--- a/t/locale.c
+++ b/t/locale.c
@@ -40,7 +40,7 @@ char *continuation[2];
 int main(int argc, char **argv) {
     int r;
 
-    size_t bufsz = 10;
+    size_t bufsz = 20;
     char in[bufsz];
     char out[bufsz];
 


### PR DESCRIPTION
This commit lets `cpipes` take advantage of all the colours available to the terminal (mostly).

On terminals that support the `initc` terminfo capability, the terminal colours are set to a colour palette. The colours of the palette may be specified with multiple `-c` options. The default is a full sweep of HSL space at maximum saturation and half lightness (i.e. the most vivid colours available), split into as many colours as are available. Some terminals with a broken `oc` capability (*cough* urxvt *cough*) do not reset colours when `delscreen` is called, which breaks the look of `ls`, `vim` and any other programs that use terminal colours. The `--backup-colors` switch can be used to try and query the current colours from the terminal and restore them before exiting. This has to work with raw escape codes, because terminfo doesn't support `initc` queries, so it's very terminal-dependent and should be avoided on terminals with a working `oc`.

On terminals that support direct colour (determined via the `RGB` terminfo capability, so this requires `ncurses >= 6`), direct colour is used to write colours, so `initc` is not used. The number of colours in the palette is still limited by the number of colour pairs available in ncurses, because ncurses does not support setting colours outside of colour pairs. Practically speaking, this is not a problem: terminals modern enough to support direct colour probably have 65535 colour pairs.

This pull requests adds some autoconf hackery to detect the features available to ncurses. We prefer `init_extended_color` over `init_color`, and `alloc_pair` over `init_extended_pair` over `init_pair`. Interestingly, using `alloc_pair` allows 65535 colour pairs to be used, but `init_extended_pair` and `init_pair` only ever allow half that, because the classic curses uses a signed `short` to store `COLOR_PAIRS`. At least, I think that's the reason: it's a mess of features shoehorned into a backwards-compatible ABI. I think this may be the only project on GitHub actually using `alloc_pair`. The others I found seem to be either implementing LISP interpreters or copies of the ncurses source.

Here's a gif in action with the parameters `"$(for i in {0..25}; do printf -- "-c 0000%02X " $((i * 10));        done)"`:

![palette](https://user-images.githubusercontent.com/396334/38145261-5cee877e-3440-11e8-837e-a39171362c9b.gif)

It suffers a bit from conversion to a gif.

It even works on the Linux terminal. It looks rubbish because the chars don't line up correctly, but the colours work (all eight of them):

![out](https://user-images.githubusercontent.com/396334/38145033-4f227dd6-343f-11e8-89f7-ffbae3e3d9bc.png)
