### PR TITLE
Fixes for build system (notably the version number)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ cpipes_SOURCES = src/cpipes.c \
 				src/render.c src/render.h \
 				src/util.c src/util.h
 cpipes_CFLAGS = $(WARN_CFLAGS)
-cpipes_LDFLAGS = $(WARN_CFLAGS)
+cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)
 cpipes_CPPFLAGS = $(CURSES_CFLAGS)
 
@@ -17,7 +17,7 @@ test_locale_SOURCES = t/locale.c \
 					  src/pipe.c src/pipe.h \
 					  src/util.c src/util.h
 test_locale_CFLAGS = -I$(srcdir)/src $(WARN_CFLAGS)
-test_locale_LDFLAGS = $(WARN_CFLAGS)
+test_locale_LDFLAGS = $(WARN_LDFLAGS)
 test_locale_LDADD = $(CURSES_LIBS)
 test_locale_CPPFLAGS = $(CURSES_CFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,9 +2,9 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.64])
 
-# Package version from `git describe --always`
+# Package version from `git describe`
 AC_INIT([pipes.c],
-        m4_esyscmd_s([git describe --always | sed 's/^v//' ]),
+        m4_esyscmd_s([git describe --always --tags --dirty | sed 's/^v//' ]),
         [stefans.mezulis@gmail.com])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([src/cpipes.c])


### PR DESCRIPTION
Fixes the issue with `git describe` described in the [review](https://github.com/pipeseroni/pipes.c/pull/22#discussion_r179875546) of #22. It's still a mystery to me how I built the 1.0.0 tarball.

Also fixes `*_LDFLAGS` in `Makefile.am`: I was passing `WARN_CFLAGS` rather than `WARN_LDFLAGS`.