### PR TITLE
Fix call to `attr_set` for ncurses < 6

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -478,7 +478,17 @@ void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state){
 
     move(p->y, p->x);
+
+    // ABI 6 and up can pass the color in the opts pointer as a pointer to an
+    // int. otherwise, we need to use the pair parameter, which is a short.
+    // The overflow should have been taken care of in palette_size, so we
+    // should just need the ABI version check.
+# if NCURSES_VERSION_MAJOR >= 6
     attr_set(A_NORMAL, 1, &p->color);
+#else
+    attr_set(A_NORMAL, p->color, NULL);
+#endif
+
     if(old_state != new_state) {
         addstr(transition_char(trans, old_state, new_state));
     }else{


### PR DESCRIPTION
Ncurses with ABI >= 6 support passing a color index to `attr_set`
through the `opts` pointer. This work-around is because the `params`
pointer must remain a `short` for backwards compatibility and the `opts`
pointer has never actually been used for anything else.

This commit adds an explicit ABI version check that uses the `params`
field when ncurses major version is < 6. I've used an explicit
preprocessor guard  rather than always calling `attr_set(..., p->color,
&p->color)` because `p->color` is an `int`, and it would overflow when
passed as the `short params` argument. Probably not a problem in
practice, but easy to avoid nonetheless.

Tested on Red Hat 7, which is where I noticed the original bug.