### PR TITLE
Fix build on NetBSD using native curses

### DIFF
--- a/src/pipe.c
+++ b/src/pipe.c
@@ -266,20 +266,20 @@ void assign_matrices(char *pipe_chars,
                 break;
             // Transition chars go ┓,┛,┗,┏
             case 2:
-                transition[RIGHT * 4 + DOWN] = c;
-                transition[UP * 4 + LEFT] = c;
+                transition[CPIPES_RIGHT * 4 + CPIPES_DOWN] = c;
+                transition[CPIPES_UP * 4 + CPIPES_LEFT] = c;
                 break;
             case 3:
-                transition[RIGHT * 4 + UP] = c;
-                transition[DOWN * 4 + LEFT] = c;
+                transition[CPIPES_RIGHT * 4 + CPIPES_UP] = c;
+                transition[CPIPES_DOWN * 4 + CPIPES_LEFT] = c;
                 break;
             case 4:
-                transition[LEFT * 4 + UP] = c;
-                transition[DOWN * 4 + RIGHT] = c;
+                transition[CPIPES_LEFT * 4 + CPIPES_UP] = c;
+                transition[CPIPES_DOWN * 4 + CPIPES_RIGHT] = c;
                 break;
             case 5:
-                transition[LEFT * 4 + DOWN] = c;
-                transition[UP * 4 + RIGHT] = c;
+                transition[CPIPES_LEFT * 4 + CPIPES_DOWN] = c;
+                transition[CPIPES_UP * 4 + CPIPES_RIGHT] = c;
                 break;
             default:
                 // No way to reach here.

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -26,10 +26,10 @@ struct pipe {
 };
 
 enum DIRECTIONS {
-    RIGHT = 0,
-    DOWN = 1,
-    LEFT = 2,
-    UP = 3
+    CPIPES_RIGHT = 0,
+    CPIPES_DOWN = 1,
+    CPIPES_LEFT = 2,
+    CPIPES_UP = 3
 };
 struct palette;
 

--- a/t/locale.c
+++ b/t/locale.c
@@ -144,17 +144,17 @@ int main(int argc, char **argv) {
     ok(!strcmp(continuation[0], "1"), "HORIZONTAL");
     ok(!strcmp(continuation[1], "2"), "VERTICAL");
 
-    ok(!strcmp(transition[RIGHT * 4 + DOWN], "3"), "RIGHT / DOWN");
-    ok(!strcmp(transition[UP * 4 + LEFT], "3"), "UP / LEFT");
+    ok(!strcmp(transition[CPIPES_RIGHT * 4 + CPIPES_DOWN], "3"), "RIGHT / DOWN");
+    ok(!strcmp(transition[CPIPES_UP * 4 + CPIPES_LEFT], "3"), "UP / LEFT");
 
-    ok(!strcmp(transition[RIGHT * 4 + UP], "4"), "RIGHT / UP");
-    ok(!strcmp(transition[DOWN * 4 + LEFT], "4"), "DOWN / LEFT");
+    ok(!strcmp(transition[CPIPES_RIGHT * 4 + CPIPES_UP], "4"), "RIGHT / UP");
+    ok(!strcmp(transition[CPIPES_DOWN * 4 + CPIPES_LEFT], "4"), "DOWN / LEFT");
 
-    ok(!strcmp(transition[LEFT * 4 + UP], "5"), "LEFT / UP");
-    ok(!strcmp(transition[DOWN * 4 + RIGHT], "5"), "DOWN / RIGHT");
+    ok(!strcmp(transition[CPIPES_LEFT * 4 + CPIPES_UP], "5"), "LEFT / UP");
+    ok(!strcmp(transition[CPIPES_DOWN * 4 + CPIPES_RIGHT], "5"), "DOWN / RIGHT");
 
-    ok(!strcmp(transition[LEFT * 4 + DOWN], "6"), "LEFT / DOWN");
-    ok(!strcmp(transition[UP * 4 + RIGHT], "6"), "UP / RIGHT");
+    ok(!strcmp(transition[CPIPES_LEFT * 4 + CPIPES_DOWN], "6"), "LEFT / DOWN");
+    ok(!strcmp(transition[CPIPES_UP * 4 + CPIPES_RIGHT], "6"), "UP / RIGHT");
     clear_error();
     return (failures > 0) ? 1 : 0;
 }


### PR DESCRIPTION
```
In file included from src/render.h:6:0,
                 from src/render.c:13:
src/pipe.h:32:5: error: 'UP' redeclared as different kind of symbol
     UP = 3
     ^
In file included from /usr/include/term.h:2002:0,
                 from src/render.c:11:
/usr/include/termcap.h:45:14: note: previous declaration of 'UP' was here
 extern char *UP;
              ^
*** Error code 1
```

When building with NetBSD's native curses library an included header: [termcap.h](https://nxr.netbsd.org/xref/src/lib/libterminfo/termcap.h#45) already has an extern symbol named "UP" which conflicts with the "DIRECTIONS" enum.