### PR TITLE
Add the "--max / -m" option for finite-length pipes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tap"]
+	path = tap
+	url = https://github.com/zorgnax/libtap.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ cpipes_SOURCES = src/cpipes.c \
 				src/render.c src/render.h \
 				src/util.c src/util.h \
 				src/err.c src/err.h \
-				src/canvas.h
+				src/canvas.h src/canvas.c
 cpipes_CFLAGS = $(WARN_CFLAGS)
 cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)
@@ -20,7 +20,8 @@ libtap_a_SOURCES = tap/tap.c tap/tap.h
 test_locale_SOURCES = t/locale.c \
 					  src/pipe.c src/pipe.h \
 					  src/util.c src/util.h \
-					  src/err.c src/err.h
+					  src/err.c src/err.h \
+					  src/canvas.c src/canvas.h
 test_locale_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_locale_LDFLAGS = $(WARN_LDFLAGS)
 test_locale_LDADD = $(CURSES_LIBS) libtap.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,13 +13,16 @@ cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)
 cpipes_CPPFLAGS = $(CURSES_CFLAGS)
 
+noinst_LIBRARIES = libtap.a
+libtap_a_SOURCES = tap/tap.c tap/tap.h
+
 test_locale_SOURCES = t/locale.c \
 					  src/pipe.c src/pipe.h \
 					  src/util.c src/util.h \
 					  src/err.c src/err.h
-test_locale_CFLAGS = -I$(srcdir)/src $(WARN_CFLAGS)
+test_locale_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_locale_LDFLAGS = $(WARN_LDFLAGS)
-test_locale_LDADD = $(CURSES_LIBS)
+test_locale_LDADD = $(CURSES_LIBS) libtap.a
 test_locale_CPPFLAGS = $(CURSES_CFLAGS)
 
 EXTRA_DIST = LICENSE README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
 				src/render.c src/render.h \
 				src/util.c src/util.h \
-				src/err.c src/err.h
+				src/err.c src/err.h \
+				src/canvas.h
 cpipes_CFLAGS = $(WARN_CFLAGS)
 cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = cpipes
 
-check_PROGRAMS = test_locale
-TESTS = test_locale
+check_PROGRAMS = test_locale test_pipe_cell_list
+TESTS = test_locale test_pipe_cell_list
 
 cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
@@ -25,5 +25,15 @@ test_locale_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_locale_LDFLAGS = $(WARN_LDFLAGS)
 test_locale_LDADD = $(CURSES_LIBS) libtap.a
 test_locale_CPPFLAGS = $(CURSES_CFLAGS)
+
+test_pipe_cell_list_SOURCES = t/pipe_cell_list.c \
+							  src/pipe.c src/pipe.h \
+							  src/util.c src/util.h \
+							  src/err.c src/err.h \
+							  src/canvas.c src/canvas.h
+test_pipe_cell_list_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
+test_pipe_cell_list_LDFLAGS = $(WARN_LDFLAGS)
+test_pipe_cell_list_LDADD = $(CURSES_LIBS) libtap.a
+test_pipe_cell_list_CPPFLAGS = $(CURSES_CFLAGS)
 
 EXTRA_DIST = LICENSE README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = cpipes
 
-check_PROGRAMS = test_locale test_pipe_cell_list
-TESTS = test_locale test_pipe_cell_list
+check_PROGRAMS = test_locale test_pipe_cell_list test_canvas
+TESTS = test_locale test_pipe_cell_list test_canvas
 
 cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
@@ -35,5 +35,15 @@ test_pipe_cell_list_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_pipe_cell_list_LDFLAGS = $(WARN_LDFLAGS)
 test_pipe_cell_list_LDADD = $(CURSES_LIBS) libtap.a
 test_pipe_cell_list_CPPFLAGS = $(CURSES_CFLAGS)
+
+test_canvas_SOURCES = t/canvas.c \
+					  src/pipe.c src/pipe.h \
+					  src/util.c src/util.h \
+					  src/err.c src/err.h \
+					  src/canvas.c src/canvas.h
+test_canvas_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
+test_canvas_LDFLAGS = $(WARN_LDFLAGS)
+test_canvas_LDADD = $(CURSES_LIBS) libtap.a
+test_canvas_CPPFLAGS = $(CURSES_CFLAGS)
 
 EXTRA_DIST = LICENSE README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,12 +3,13 @@ bin_PROGRAMS = cpipes
 check_PROGRAMS = test_locale test_pipe_cell_list test_canvas test_cbuf
 TESTS = test_locale test_pipe_cell_list test_canvas test_cbuf
 
-cpipes_SOURCES = src/cpipes.c \
-				src/pipe.c src/pipe.h \
-				src/render.c src/render.h \
-				src/util.c src/util.h \
-				src/err.c src/err.h \
-				src/canvas.h src/canvas.c
+SOURCES = src/pipe.c src/pipe.h \
+		  src/render.c src/render.h \
+		  src/util.c src/util.h \
+		  src/err.c src/err.h \
+		  src/canvas.h src/canvas.c
+
+cpipes_SOURCES = src/cpipes.c $(SOURCES)
 cpipes_CFLAGS = $(WARN_CFLAGS)
 cpipes_LDFLAGS = $(WARN_LDFLAGS)
 cpipes_LDADD = $(CURSES_LIBS)
@@ -17,41 +18,25 @@ cpipes_CPPFLAGS = $(CURSES_CFLAGS)
 noinst_LIBRARIES = libtap.a
 libtap_a_SOURCES = tap/tap.c tap/tap.h
 
-test_locale_SOURCES = t/locale.c \
-					  src/pipe.c src/pipe.h \
-					  src/util.c src/util.h \
-					  src/err.c src/err.h \
-					  src/canvas.c src/canvas.h
+test_locale_SOURCES = t/locale.c $(SOURCES)
 test_locale_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_locale_LDFLAGS = $(WARN_LDFLAGS)
 test_locale_LDADD = $(CURSES_LIBS) libtap.a
 test_locale_CPPFLAGS = $(CURSES_CFLAGS)
 
-test_pipe_cell_list_SOURCES = t/pipe_cell_list.c \
-							  src/pipe.c src/pipe.h \
-							  src/util.c src/util.h \
-							  src/err.c src/err.h \
-							  src/canvas.c src/canvas.h
+test_pipe_cell_list_SOURCES = t/pipe_cell_list.c $(SOURCES)
 test_pipe_cell_list_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_pipe_cell_list_LDFLAGS = $(WARN_LDFLAGS)
 test_pipe_cell_list_LDADD = $(CURSES_LIBS) libtap.a
 test_pipe_cell_list_CPPFLAGS = $(CURSES_CFLAGS)
 
-test_canvas_SOURCES = t/canvas.c \
-					  src/pipe.c src/pipe.h \
-					  src/util.c src/util.h \
-					  src/err.c src/err.h \
-					  src/canvas.c src/canvas.h
+test_canvas_SOURCES = t/canvas.c $(SOURCES)
 test_canvas_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_canvas_LDFLAGS = $(WARN_LDFLAGS)
 test_canvas_LDADD = $(CURSES_LIBS) libtap.a
 test_canvas_CPPFLAGS = $(CURSES_CFLAGS)
 
-test_cbuf_SOURCES = t/test_cbuf.c \
-					src/pipe.c src/pipe.h \
-					src/util.c src/util.h \
-					src/err.c src/err.h \
-					src/canvas.c src/canvas.h
+test_cbuf_SOURCES = t/test_cbuf.c $(SOURCES)
 test_cbuf_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_cbuf_LDFLAGS = $(WARN_LDFLAGS)
 test_cbuf_LDADD = $(CURSES_LIBS) libtap.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ SOURCES = src/pipe.c src/pipe.h \
 		  src/render.c src/render.h \
 		  src/util.c src/util.h \
 		  src/err.c src/err.h \
+		  src/pipe_cell_list.c src/pipe_cell_list.h \
 		  src/canvas.h src/canvas.c
 
 cpipes_SOURCES = src/cpipes.c $(SOURCES)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = cpipes
 
-check_PROGRAMS = test_locale test_pipe_cell_list test_canvas
-TESTS = test_locale test_pipe_cell_list test_canvas
+check_PROGRAMS = test_locale test_pipe_cell_list test_canvas test_cbuf
+TESTS = test_locale test_pipe_cell_list test_canvas test_cbuf
 
 cpipes_SOURCES = src/cpipes.c \
 				src/pipe.c src/pipe.h \
@@ -45,5 +45,15 @@ test_canvas_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
 test_canvas_LDFLAGS = $(WARN_LDFLAGS)
 test_canvas_LDADD = $(CURSES_LIBS) libtap.a
 test_canvas_CPPFLAGS = $(CURSES_CFLAGS)
+
+test_cbuf_SOURCES = t/test_cbuf.c \
+					src/pipe.c src/pipe.h \
+					src/util.c src/util.h \
+					src/err.c src/err.h \
+					src/canvas.c src/canvas.h
+test_cbuf_CFLAGS = -I$(srcdir)/src -isystem tap $(WARN_CFLAGS)
+test_cbuf_LDFLAGS = $(WARN_LDFLAGS)
+test_cbuf_LDADD = $(CURSES_LIBS) libtap.a
+test_cbuf_CPPFLAGS = $(CURSES_CFLAGS)
 
 EXTRA_DIST = LICENSE README.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ SOURCES = src/pipe.c src/pipe.h \
 		  src/util.c src/util.h \
 		  src/err.c src/err.h \
 		  src/pipe_cell_list.c src/pipe_cell_list.h \
+		  src/location_buffer.c src/location_buffer.h \
 		  src/canvas.h src/canvas.c
 
 cpipes_SOURCES = src/cpipes.c $(SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,8 @@ AC_INIT([pipes.c],
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_SRCDIR([src/cpipes.c])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AM_PROG_AR
+AC_PROG_RANLIB
 AC_PROG_SED
 AC_LANG([C])
 AC_PROG_CC_C99

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -1,0 +1,65 @@
+#include <config.h>
+
+#include <stdlib.h>
+#include "pipe.h"
+#include "canvas.h"
+
+struct pipe_cell_list *pipe_cell_list_alloc(void) {
+    struct pipe_cell_list *p;
+    p = malloc(sizeof(*p));
+
+    pipe_cell_list_init(p);
+    return p;
+}
+
+void pipe_cell_list_init(struct pipe_cell_list *list) {
+    list->head = list->tail = NULL;
+}
+
+cpipes_errno pipe_cell_list_push(
+        struct pipe_cell_list *list,
+        const char *pipe_char, struct pipe *pipe) {
+
+    struct pipe_cell *cell;
+    cell = malloc(sizeof(*cell));
+    if(!cell)
+        return set_error(ERR_OUT_OF_MEMORY);
+
+    cell->pipe_char = pipe_char;
+    cell->color = pipe->color;
+    cell->pipe = pipe;
+
+    cell->next = list->head;
+    cell->prev = NULL;
+
+    if(!list->head)
+        list->tail = cell;
+    else
+        list->head->prev = cell;
+    list->head = cell;
+
+    return 0;
+}
+
+void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe) {
+    for(struct pipe_cell *c = list->tail; c; c = c->prev) {
+        if(c->pipe == pipe) {
+            if(c == list->head)
+                list->head = c->next;
+            if(c == list->tail)
+                list->tail = c->prev;
+            if(c->prev)
+                c->prev->next = c->next;
+            if(c->next)
+                c->next->prev = c->prev;
+            free(c);
+            break;
+        }
+    }
+}
+
+void pipe_cell_list_free(struct pipe_cell_list *list) {
+    for(struct pipe_cell *c = list->head; c; c = c->next)
+        free(c->prev);
+    free(list->tail);
+}

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -109,3 +109,42 @@ void canvas_free(struct canvas *canvas) {
         pipe_cell_list_free(&canvas->cells[i]);
     free(canvas->cells);
 }
+
+cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max) {
+    buffer->locations = malloc(sizeof(*buffer->locations) * max);
+    if(!buffer->locations)
+        return set_error(ERR_OUT_OF_MEMORY);
+
+    buffer->max = max;
+    buffer->size = 0;
+    buffer->head = 0;
+    return 0;
+}
+void location_buffer_free(struct location_buffer *buffer) {
+    free(buffer->locations);
+}
+
+unsigned int *location_buffer_head(struct location_buffer *buffer) {
+    if(buffer->size == 0)
+        return NULL;
+    return &buffer->locations[buffer->head];
+}
+unsigned int *location_buffer_tail(struct location_buffer *buffer) {
+    if(buffer->size == 0)
+        return NULL;
+    size_t tail = (buffer->head + 1) % buffer->size;
+    return &buffer->locations[tail];
+}
+
+void location_buffer_push(struct location_buffer *buffer, unsigned int loc) {
+    if(buffer->size == 0) {
+        buffer->locations[buffer->head] = loc;
+        buffer->size++;
+    } else if(buffer->size < buffer->max) {
+        buffer->locations[++buffer->head] = loc;
+        buffer->size++;
+    } else {
+        buffer->head = (buffer->head + 1) % buffer->size;
+        buffer->locations[buffer->head] = loc;
+    }
+}

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "pipe.h"
 #include "pipe_cell_list.h"
+#include "location_buffer.h"
 #include "canvas.h"
 
 /** The canvas "cells" contain a list of the pipe characters (and colors) that
@@ -78,41 +79,3 @@ void canvas_erase_tail(struct canvas *c,
     }
 }
 
-cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max) {
-    buffer->locations = malloc(sizeof(*buffer->locations) * max);
-    if(!buffer->locations)
-        return set_error(ERR_OUT_OF_MEMORY);
-
-    buffer->max = max;
-    buffer->size = 0;
-    buffer->head = 0;
-    return 0;
-}
-void location_buffer_free(struct location_buffer *buffer) {
-    free(buffer->locations);
-}
-
-unsigned int *location_buffer_head(struct location_buffer *buffer) {
-    if(buffer->size == 0)
-        return NULL;
-    return &buffer->locations[buffer->head];
-}
-unsigned int *location_buffer_tail(struct location_buffer *buffer) {
-    if(buffer->size == 0)
-        return NULL;
-    size_t tail = (buffer->head + 1) % buffer->size;
-    return &buffer->locations[tail];
-}
-
-void location_buffer_push(struct location_buffer *buffer, unsigned int loc) {
-    if(buffer->size == 0) {
-        buffer->locations[buffer->head] = loc;
-        buffer->size++;
-    } else if(buffer->size < buffer->max) {
-        buffer->locations[++buffer->head] = loc;
-        buffer->size++;
-    } else {
-        buffer->head = (buffer->head + 1) % buffer->size;
-        buffer->locations[buffer->head] = loc;
-    }
-}

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -3,67 +3,8 @@
 #include <curses.h>
 #include <stdlib.h>
 #include "pipe.h"
+#include "pipe_cell_list.h"
 #include "canvas.h"
-
-struct pipe_cell_list *pipe_cell_list_alloc(void) {
-    struct pipe_cell_list *p;
-    p = malloc(sizeof(*p));
-
-    pipe_cell_list_init(p);
-    return p;
-}
-
-void pipe_cell_list_init(struct pipe_cell_list *list) {
-    list->head = list->tail = NULL;
-}
-
-cpipes_errno pipe_cell_list_push(
-        struct pipe_cell_list *list,
-        const char *pipe_char, struct pipe *pipe) {
-
-    struct pipe_cell *cell;
-    cell = malloc(sizeof(*cell));
-    if(!cell)
-        return set_error(ERR_OUT_OF_MEMORY);
-
-    cell->pipe_char = pipe_char;
-    cell->color = pipe->color;
-    cell->pipe = pipe;
-
-    cell->next = list->head;
-    cell->prev = NULL;
-
-    if(!list->head)
-        list->tail = cell;
-    else
-        list->head->prev = cell;
-    list->head = cell;
-
-    return 0;
-}
-
-void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe) {
-    for(struct pipe_cell *c = list->tail; c; c = c->prev) {
-        if(c->pipe == pipe) {
-            if(c == list->head)
-                list->head = c->next;
-            if(c == list->tail)
-                list->tail = c->prev;
-            if(c->prev)
-                c->prev->next = c->next;
-            if(c->next)
-                c->next->prev = c->prev;
-            free(c);
-            break;
-        }
-    }
-}
-
-void pipe_cell_list_free(struct pipe_cell_list *list) {
-    for(struct pipe_cell *c = list->head; c; c = c->next)
-        free(c->prev);
-    free(list->tail);
-}
 
 /** The canvas "cells" contain a list of the pipe characters (and colors) that
  * have been written to that (x, y) coordinate. Cells are stored in a row-major

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -7,6 +7,7 @@
 
 struct pipe;
 struct pipe_cell_list;
+struct location_buffer;
 
 struct palette {
     uint32_t *colors;
@@ -34,20 +35,6 @@ cpipes_errno canvas_resize(
 void canvas_free(struct canvas *canvas);
 void canvas_erase_tail(struct canvas *c,
         unsigned int tail, struct pipe *p);
-
-// Circular buffer containing the locations of a pipe
-struct location_buffer {
-    unsigned int *locations;
-    size_t max, size, head;
-};
-
-cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max);
-void location_buffer_free(struct location_buffer *buffer);
-
-unsigned int *location_buffer_head(struct location_buffer *buffer);
-unsigned int *location_buffer_tail(struct location_buffer *buffer);
-
-void location_buffer_push(struct location_buffer *buffer, unsigned int loc);
 
 #endif /* CANVAS_H_ */
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -5,6 +5,27 @@
 #include <stdint.h>
 #include "err.h"
 
+struct pipe;
+
+struct pipe_cell {
+    const char *pipe_char;
+    uint32_t color;
+    struct pipe *pipe;
+    struct pipe_cell *next, *prev;
+};
+
+struct pipe_cell_list {
+    struct pipe_cell *head, *tail;
+};
+
+struct pipe_cell_list *pipe_cell_list_alloc(void);
+void pipe_cell_list_init(struct pipe_cell_list *list);
+cpipes_errno pipe_cell_list_push(
+        struct pipe_cell_list *list,
+        const char *pipe_char, struct pipe *pipe);
+void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe);
+void pipe_cell_list_free(struct pipe_cell_list *list);
+
 struct palette {
     uint32_t *colors;
     size_t num_colors;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -51,5 +51,19 @@ cpipes_errno canvas_resize(
         unsigned int width, unsigned int height);
 void canvas_free(struct canvas *canvas);
 
+// Circular buffer containing the locations of a pipe
+struct location_buffer {
+    unsigned int *locations;
+    size_t max, size, head;
+};
+
+cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max);
+void location_buffer_free(struct location_buffer *buffer);
+
+unsigned int *location_buffer_head(struct location_buffer *buffer);
+unsigned int *location_buffer_tail(struct location_buffer *buffer);
+
+void location_buffer_push(struct location_buffer *buffer, unsigned int loc);
+
 #endif /* CANVAS_H_ */
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -40,7 +40,16 @@ struct canvas {
     unsigned int width, height;
     struct palette palette;
     struct color_backup backup;
+    struct pipe_cell_list *cells;
 };
+
+cpipes_errno canvas_init(
+        struct canvas *canvas,
+        unsigned int width, unsigned int height);
+cpipes_errno canvas_resize(
+        struct canvas *canvas,
+        unsigned int width, unsigned int height);
+void canvas_free(struct canvas *canvas);
 
 #endif /* CANVAS_H_ */
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -50,6 +50,8 @@ cpipes_errno canvas_resize(
         struct canvas *canvas,
         unsigned int width, unsigned int height);
 void canvas_free(struct canvas *canvas);
+void canvas_erase_tail(struct canvas *c,
+        unsigned int tail, struct pipe *p);
 
 // Circular buffer containing the locations of a pipe
 struct location_buffer {

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -1,0 +1,25 @@
+#ifndef CANVAS_H_
+#define CANVAS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include "err.h"
+
+struct palette {
+    uint32_t *colors;
+    size_t num_colors;
+};
+
+struct color_backup {
+    size_t num_colors;
+    char **escape_codes;
+};
+
+struct canvas {
+    unsigned int width, height;
+    struct palette palette;
+    struct color_backup backup;
+};
+
+#endif /* CANVAS_H_ */
+

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -6,25 +6,7 @@
 #include "err.h"
 
 struct pipe;
-
-struct pipe_cell {
-    const char *pipe_char;
-    uint32_t color;
-    struct pipe *pipe;
-    struct pipe_cell *next, *prev;
-};
-
-struct pipe_cell_list {
-    struct pipe_cell *head, *tail;
-};
-
-struct pipe_cell_list *pipe_cell_list_alloc(void);
-void pipe_cell_list_init(struct pipe_cell_list *list);
-cpipes_errno pipe_cell_list_push(
-        struct pipe_cell_list *list,
-        const char *pipe_char, struct pipe *pipe);
-void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe);
-void pipe_cell_list_free(struct pipe_cell_list *list);
+struct pipe_cell_list;
 
 struct palette {
     uint32_t *colors;

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -16,6 +16,7 @@
 
 #include "canvas.h"
 #include "pipe.h"
+#include "pipe_cell_list.h"
 #include "render.h"
 #include "util.h"
 

--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -17,6 +17,7 @@
 #include "canvas.h"
 #include "pipe.h"
 #include "pipe_cell_list.h"
+#include "location_buffer.h"
 #include "render.h"
 #include "util.h"
 

--- a/src/err.c
+++ b/src/err.c
@@ -47,8 +47,8 @@ static void err_provenance(const char *file, int line, const char *function) {
 }
 
 
-/** Store message in buffer. */
-void set_error_(const char *file, int line, const char *function,
+/** Store message in buffer. Returns the err_num for convenience. */
+cpipes_errno set_error_(const char *file, int line, const char *function,
         cpipes_errno err_num, ...) {
     assert(ERR_ICONV_ERROR <= err_num && err_num <= ERR_CURSES_ERR
             /* Error number is within the correct range */);
@@ -69,6 +69,8 @@ void set_error_(const char *file, int line, const char *function,
     // Always terminate with a nul, even if snprintf didn't allow anything to
     // actually be appended.
     ERR_BUF[ERR_BUF_SZ - 1] = '\0';
+
+    return err_num;
 }
 
 #ifdef HAVE_FUNC_ATTRIBUTE_FORMAT

--- a/src/err.h
+++ b/src/err.h
@@ -27,7 +27,7 @@ typedef enum PIPES_C_ERRORS cpipes_errno;
         __VA_ARGS__)
 
 /** Called by set_error macro with __FILE__, __LINE__ and __func__ */
-void set_error_(const char *file, int line, const char *function,
+cpipes_errno set_error_(const char *file, int line, const char *function,
         cpipes_errno err_num, ...);
 void add_error_info_(const char *file, int line, const char *function,
         const char *fmt, ...);

--- a/src/location_buffer.c
+++ b/src/location_buffer.c
@@ -1,0 +1,43 @@
+#include <config.h>
+
+#include <stdlib.h>
+#include "location_buffer.h"
+
+cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max) {
+    buffer->locations = malloc(sizeof(*buffer->locations) * max);
+    if(!buffer->locations)
+        return set_error(ERR_OUT_OF_MEMORY);
+
+    buffer->max = max;
+    buffer->size = 0;
+    buffer->head = 0;
+    return 0;
+}
+void location_buffer_free(struct location_buffer *buffer) {
+    free(buffer->locations);
+}
+
+unsigned int *location_buffer_head(struct location_buffer *buffer) {
+    if(buffer->size == 0)
+        return NULL;
+    return &buffer->locations[buffer->head];
+}
+unsigned int *location_buffer_tail(struct location_buffer *buffer) {
+    if(buffer->size == 0)
+        return NULL;
+    size_t tail = (buffer->head + 1) % buffer->size;
+    return &buffer->locations[tail];
+}
+
+void location_buffer_push(struct location_buffer *buffer, unsigned int loc) {
+    if(buffer->size == 0) {
+        buffer->locations[buffer->head] = loc;
+        buffer->size++;
+    } else if(buffer->size < buffer->max) {
+        buffer->locations[++buffer->head] = loc;
+        buffer->size++;
+    } else {
+        buffer->head = (buffer->head + 1) % buffer->size;
+        buffer->locations[buffer->head] = loc;
+    }
+}

--- a/src/location_buffer.h
+++ b/src/location_buffer.h
@@ -1,0 +1,21 @@
+#ifndef LOCATION_BUFFER_H_
+#define LOCATION_BUFFER_H_
+
+#include "err.h"
+
+// Circular buffer containing the locations of a pipe
+struct location_buffer {
+    unsigned int *locations;
+    size_t max, size, head;
+};
+
+cpipes_errno location_buffer_init(struct location_buffer *buffer, size_t max);
+void location_buffer_free(struct location_buffer *buffer);
+
+unsigned int *location_buffer_head(struct location_buffer *buffer);
+unsigned int *location_buffer_tail(struct location_buffer *buffer);
+
+void location_buffer_push(struct location_buffer *buffer, unsigned int loc);
+
+#endif /* LOCATION_BUFFER_H_ */
+

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -13,6 +13,7 @@
 #include "pipe.h"
 #include "util.h"
 #include "render.h"
+#include "location_buffer.h"
 
 /* This file contains functions for managing the initialisation and movement of
  * a pipe.

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -312,21 +312,20 @@ cpipes_errno multicolumn_adjust(char **continuation) {
  * function makes sure to only assign initial positions at full-character
  * boundaries.
  */
-void init_pipe(struct pipe *pipe, struct palette *palette,
-        int initial_state,
-        unsigned int width, unsigned int height){
+void init_pipe(struct pipe *pipe, struct canvas *canvas, int initial_state) {
     // Multicolumn chars shouldn't be placed off the end of the screen
     size_t colwidth = max(states[0][0], -states[2][0]);
-    width -= width % colwidth;
+    unsigned int width = canvas->width;
+    width -= canvas->width % colwidth;
 
     if(initial_state < 0)
         pipe->state = randrange(0, 4);
     else
         pipe->state = initial_state;
-    random_pipe_color(pipe, palette);
+    random_pipe_color(pipe, &canvas->palette);
     pipe->length = 0;
     pipe->x = randrange(0, width / colwidth) * colwidth;
-    pipe->y = randrange(0, height / colwidth) * colwidth;
+    pipe->y = randrange(0, canvas->height / colwidth) * colwidth;
 }
 
 /** Move a pipe by the amount given by the current state. If
@@ -344,16 +343,21 @@ void move_pipe(struct pipe *pipe){
  * characters, wrap the pipe before it gets a chance to spit out incomplete
  * characters.
  */
-bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height){
+bool wrap_pipe(struct pipe *pipe, struct canvas *canvas){
     // Take multi-column chars into account
+    unsigned int width = canvas->width;
     width -= width % max(states[0][1], -states[2][0]);
 
     if(pipe->x < 0 || (unsigned int) pipe->x >= width
-            || pipe->y < 0 || (unsigned int) pipe->y >= height){
-        if(pipe->x < 0){ pipe->x += width; }
-        if(pipe->y < 0){ pipe->y += height; }
-        if((unsigned int) pipe->x >= width) {pipe->x -= width; }
-        if((unsigned int) pipe->y >= height) {pipe->y -= height; }
+            || pipe->y < 0 || (unsigned int) pipe->y >= canvas->height){
+        if(pipe->x < 0)
+            pipe->x += width;
+        if(pipe->y < 0)
+            pipe->y += canvas->height;
+        if((unsigned int) pipe->x >= canvas->width)
+            pipe->x -= width;
+        if((unsigned int) pipe->y >= canvas->height)
+            pipe->y -= canvas->height;
         return true;
     }
     return false;

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -4,7 +4,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "err.h"
-#include "canvas.h"
+
+struct canvas;
 
 //States and transition characters
 extern char states[][2];
@@ -24,6 +25,7 @@ struct pipe {
     unsigned int color;
     unsigned short length;
     int x, y;
+    struct location_buffer *locations;
 };
 
 enum DIRECTIONS {
@@ -34,9 +36,11 @@ enum DIRECTIONS {
 };
 struct palette;
 
-void init_pipe(struct pipe *pipe, struct canvas *canvas, int initial_state);
-void move_pipe(struct pipe *pipe);
+cpipes_errno init_pipe(struct pipe *pipe, struct canvas *canvas,
+        int initial_state, unsigned int max_len);
+void move_pipe(struct pipe *pipe, struct canvas *canvas);
 bool wrap_pipe(struct pipe *pipe, struct canvas *canvas);
+void erase_pipe_tail(struct pipe *pipe, struct canvas *canvas);
 char flip_pipe_state(struct pipe *pipe);
 void random_pipe_color(struct pipe *pipe, struct palette *palette);
 bool should_flip_state(struct pipe *p, int min_len, float prob);

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "err.h"
+#include "canvas.h"
 
 //States and transition characters
 extern char states[][2];
@@ -33,11 +34,9 @@ enum DIRECTIONS {
 };
 struct palette;
 
-void init_pipe(struct pipe *pipe, struct palette *palette,
-        int initial_state,
-        unsigned int width, unsigned int height);
+void init_pipe(struct pipe *pipe, struct canvas *canvas, int initial_state);
 void move_pipe(struct pipe *pipe);
-bool wrap_pipe(struct pipe *pipe, unsigned int width, unsigned int height);
+bool wrap_pipe(struct pipe *pipe, struct canvas *canvas);
 char flip_pipe_state(struct pipe *pipe);
 void random_pipe_color(struct pipe *pipe, struct palette *palette);
 bool should_flip_state(struct pipe *p, int min_len, float prob);

--- a/src/pipe_cell_list.c
+++ b/src/pipe_cell_list.c
@@ -1,0 +1,66 @@
+#include <config.h>
+
+#include <stdlib.h>
+#include "pipe.h"
+#include "pipe_cell_list.h"
+
+struct pipe_cell_list *pipe_cell_list_alloc(void) {
+    struct pipe_cell_list *p;
+    p = malloc(sizeof(*p));
+
+    pipe_cell_list_init(p);
+    return p;
+}
+
+void pipe_cell_list_init(struct pipe_cell_list *list) {
+    list->head = list->tail = NULL;
+}
+
+cpipes_errno pipe_cell_list_push(
+        struct pipe_cell_list *list,
+        const char *pipe_char, struct pipe *pipe) {
+
+    struct pipe_cell *cell;
+    cell = malloc(sizeof(*cell));
+    if(!cell)
+        return set_error(ERR_OUT_OF_MEMORY);
+
+    cell->pipe_char = pipe_char;
+    cell->color = pipe->color;
+    cell->pipe = pipe;
+
+    cell->next = list->head;
+    cell->prev = NULL;
+
+    if(!list->head)
+        list->tail = cell;
+    else
+        list->head->prev = cell;
+    list->head = cell;
+
+    return 0;
+}
+
+void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe) {
+    for(struct pipe_cell *c = list->tail; c; c = c->prev) {
+        if(c->pipe == pipe) {
+            if(c == list->head)
+                list->head = c->next;
+            if(c == list->tail)
+                list->tail = c->prev;
+            if(c->prev)
+                c->prev->next = c->next;
+            if(c->next)
+                c->next->prev = c->prev;
+            free(c);
+            break;
+        }
+    }
+}
+
+void pipe_cell_list_free(struct pipe_cell_list *list) {
+    for(struct pipe_cell *c = list->head; c; c = c->next)
+        free(c->prev);
+    free(list->tail);
+}
+

--- a/src/pipe_cell_list.h
+++ b/src/pipe_cell_list.h
@@ -1,0 +1,28 @@
+#ifndef PIPE_CELL_LIST_H_
+#define PIPE_CELL_LIST_H_
+#include <stdint.h>
+
+struct pipe;
+
+struct pipe_cell {
+    const char *pipe_char;
+    uint32_t color;
+    struct pipe *pipe;
+    struct pipe_cell *next, *prev;
+};
+
+struct pipe_cell_list {
+    struct pipe_cell *head, *tail;
+};
+
+struct pipe_cell_list *pipe_cell_list_alloc(void);
+void pipe_cell_list_init(struct pipe_cell_list *list);
+cpipes_errno pipe_cell_list_push(
+        struct pipe_cell_list *list,
+        const char *pipe_char, struct pipe *pipe);
+void pipe_cell_list_remove(struct pipe_cell_list *list, struct pipe *pipe);
+void pipe_cell_list_free(struct pipe_cell_list *list);
+
+
+#endif /* PIPE_CELL_LIST_H_ */
+

--- a/src/render.c
+++ b/src/render.c
@@ -310,8 +310,7 @@ int set_color_pair_direct(int color_index, uint32_t color) {
     return set_pair(color_index, color, COLOR_BLACK);
 }
 
-void animate(int fps, anim_function renderer,
-        unsigned int *width, unsigned int *height,
+void animate(int fps, anim_function renderer, struct canvas *canvas,
         volatile sig_atomic_t *interrupted, void *data){
     //Store start time
     struct timespec start_time;
@@ -323,7 +322,7 @@ void animate(int fps, anim_function renderer,
 
         // If we received a SIGWINCH, update width and height
         if(key == KEY_RESIZE) {
-            getmaxyx(stdscr, *height, *width);
+            getmaxyx(stdscr, canvas->height, canvas->width);
         }else if(key != ERR) {
             // Any actual keypresses should quit the program.
             break;
@@ -332,7 +331,7 @@ void animate(int fps, anim_function renderer,
         clock_gettime(CLOCK_REALTIME, &start_time);
 
         //Render
-        (*renderer)(*width, *height, data);
+        (*renderer)(canvas, data);
 
         //Get end time
         struct timespec end_time;

--- a/src/render.h
+++ b/src/render.h
@@ -5,26 +5,16 @@
 #include <stdint.h>
 #include "pipe.h"
 #include "err.h"
+#include "canvas.h"
 
-struct palette {
-    uint32_t *colors;
-    size_t num_colors;
-};
-
-struct color_backup {
-    size_t num_colors;
-    char **escape_codes;
-};
-
-typedef void (*anim_function)(unsigned int width, unsigned int height,
-        void *data);
+typedef void (*anim_function)(struct canvas *canvas, void *data);
 
 cpipes_errno init_color_palette(uint32_t *colors, size_t num_colors,
         struct palette *palette, struct color_backup *backup);
 
 void init_colors(void);
 void animate(int fps, anim_function renderer,
-        unsigned int *width, unsigned int *height,
+        struct canvas *canvas,
         volatile sig_atomic_t *interrupted, void *data);
 void render_pipe(struct pipe *p, char **trans, char **pipe_chars,
         int old_state, int new_state);

--- a/t/canvas.c
+++ b/t/canvas.c
@@ -1,0 +1,34 @@
+#include <tap.h>
+
+#include <pipe.h>
+#include <canvas.h>
+
+#define BUF_SZ 3
+
+struct pipe dummy_pipe = {1, 1, 1, 1, 1};
+
+int main(int argc, char **argv) {
+    struct canvas c;
+    cpipes_errno err;
+
+    diag("This test should be checked with valgrind for memory errors.");
+    diag("All memory should be freed by the time the test terminates.");
+
+    diag("Initialising a 2x2 canvas.");
+    err = canvas_init(&c, 2, 2);
+    cmp_ok(c.width, "==", 2, "Canvas width set to 2.");
+    cmp_ok(c.height, "==", 2, "Canvas height set to 2.");
+    cmp_ok(err, "==", 0, "No error initialising canvas (err = %d)", err);
+
+    pipe_cell_list_push(&c.cells[3], "A", &dummy_pipe);
+    ok(c.cells[3].head->pipe == &dummy_pipe, "Retrieved pipe.");
+
+    diag("Resizing to a 3x1 canvas.");
+    canvas_resize(&c, 3, 1);
+    cmp_ok(c.width, "==", 3, "Canvas width set to 3.");
+    cmp_ok(c.height, "==", 1, "Canvas height set to 1.");
+
+    canvas_free(&c);
+    done_testing();
+    return 0;
+}

--- a/t/canvas.c
+++ b/t/canvas.c
@@ -2,6 +2,7 @@
 
 #include <pipe.h>
 #include <canvas.h>
+#include <pipe_cell_list.h>
 
 #define BUF_SZ 3
 

--- a/t/locale.c
+++ b/t/locale.c
@@ -4,23 +4,14 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <tap.h>
+
 #include "pipe.h"
 #include "err.h"
 /**
  * Check locale-encoding functions.
  */
 #define NUM_TESTS 30
-
-// TAP-producing ok() function
-static int testnum = 1;
-static int failures = 0;
-
-static void ok(bool condition, const char* msg);
-static void ok(bool condition, const char* msg) {
-    printf("%s %d - %s\n", condition ? "ok" : "not ok", testnum++, msg);
-    if(!condition)
-        failures++;
-}
 
 // These are the same in UTF8 and GB18030
 const char *UTF8_ASCII = "123";
@@ -44,24 +35,23 @@ int main(int argc, char **argv) {
     char in[bufsz];
     char out[bufsz];
 
-    printf("1..%d\n", NUM_TESTS);
+    plan(NUM_TESTS);
 
     // Identity conversion with ASCII bytes
     strcpy(in, UTF8_ASCII);
     r = locale_to_utf8(in, out, "UTF-8", 4);
     ok(r == 0,
         "ASCII UTF8 to UTF8 in 4 bytes: no error code.");
-    ok(strcmp(out, UTF8_ASCII) == 0,
-        "ASCII UTF8 to UTF8 copied correctly");
+    is(out, UTF8_ASCII, "ASCII UTF8 to UTF8 copied correctly");
     clear_error();
 
     r = locale_to_utf8(in, out, "UTF-8", 3);
     ok(r == ERR_BUFFER_TOO_SMALL,
         "ASCII UTF8 to UTF8 in 3 bytes: buffer too small.");
 
-    ok(strstr(string_error(), "Buffer (3 items) too small"),
+    like(string_error(), "Buffer \\(3 items\\) too small",
         "Error text contains buffer size.");
-    ok(strstr(string_error(), "tried to insert 4 items"),
+    like(string_error(), "tried to insert 4 items",
         "Error text contains inserted size.");
     clear_error();
 
@@ -70,8 +60,7 @@ int main(int argc, char **argv) {
     r = locale_to_utf8(in, out, "UTF-8", 7);
     ok(r == 0,
         "Box UTF8 to UTF8 in 7 bytes: no error code.");
-    ok(strcmp(out, UTF8_BOX) == 0,
-        "Box UTF8 to UTF8 copied correctly.");
+    is(out, UTF8_BOX, "Box UTF8 to UTF8 copied correctly.");
     clear_error();
 
     r = locale_to_utf8(in, out, "UTF-8", 6);
@@ -84,8 +73,7 @@ int main(int argc, char **argv) {
     r = locale_to_utf8(in, out, "GB18030", 4);
     ok(r == 0,
         "ASCII GB18030 to UTF8 in 4 bytes: no error code.");
-    ok(strcmp(out, UTF8_ASCII) == 0,
-        "ASCII UTF8 to GB18030 copied correctly");
+    is(out, UTF8_ASCII, "ASCII UTF8 to GB18030 copied correctly");
     clear_error();
 
     r = locale_to_utf8(in, out, "GB18030", 3);
@@ -98,8 +86,7 @@ int main(int argc, char **argv) {
     r = locale_to_utf8(in, out, "GB18030", 7);
     ok(r == 0,
         "Box GB18030 to UTF8 in 7 bytes: no error code.");
-    ok(strcmp(out, UTF8_BOX) == 0,
-        "Box GB18030 to UTF8 copied correctly.");
+    is(out, UTF8_BOX, "Box GB18030 to UTF8 copied correctly.");
     clear_error();
 
     r = locale_to_utf8(in, out, "GB18030", 6);
@@ -141,20 +128,21 @@ int main(int argc, char **argv) {
 
     assign_matrices(in, transition, continuation);
 
-    ok(!strcmp(continuation[0], "1"), "HORIZONTAL");
-    ok(!strcmp(continuation[1], "2"), "VERTICAL");
+    is(continuation[0], "1", "HORIZONTAL");
+    is(continuation[1], "2", "VERTICAL");
 
-    ok(!strcmp(transition[CPIPES_RIGHT * 4 + CPIPES_DOWN], "3"), "RIGHT / DOWN");
-    ok(!strcmp(transition[CPIPES_UP * 4 + CPIPES_LEFT], "3"), "UP / LEFT");
+    is(transition[CPIPES_RIGHT * 4 + CPIPES_DOWN], "3", "RIGHT / DOWN");
+    is(transition[CPIPES_UP * 4 + CPIPES_LEFT], "3", "UP / LEFT");
 
-    ok(!strcmp(transition[CPIPES_RIGHT * 4 + CPIPES_UP], "4"), "RIGHT / UP");
-    ok(!strcmp(transition[CPIPES_DOWN * 4 + CPIPES_LEFT], "4"), "DOWN / LEFT");
+    is(transition[CPIPES_RIGHT * 4 + CPIPES_UP], "4", "RIGHT / UP");
+    is(transition[CPIPES_DOWN * 4 + CPIPES_LEFT], "4", "DOWN / LEFT");
 
-    ok(!strcmp(transition[CPIPES_LEFT * 4 + CPIPES_UP], "5"), "LEFT / UP");
-    ok(!strcmp(transition[CPIPES_DOWN * 4 + CPIPES_RIGHT], "5"), "DOWN / RIGHT");
+    is(transition[CPIPES_LEFT * 4 + CPIPES_UP], "5", "LEFT / UP");
+    is(transition[CPIPES_DOWN * 4 + CPIPES_RIGHT], "5", "DOWN / RIGHT");
 
-    ok(!strcmp(transition[CPIPES_LEFT * 4 + CPIPES_DOWN], "6"), "LEFT / DOWN");
-    ok(!strcmp(transition[CPIPES_UP * 4 + CPIPES_RIGHT], "6"), "UP / RIGHT");
+    is(transition[CPIPES_LEFT * 4 + CPIPES_DOWN], "6", "LEFT / DOWN");
+    is(transition[CPIPES_UP * 4 + CPIPES_RIGHT], "6", "UP / RIGHT");
     clear_error();
-    return (failures > 0) ? 1 : 0;
+
+    done_testing();
 }

--- a/t/pipe_cell_list.c
+++ b/t/pipe_cell_list.c
@@ -1,0 +1,76 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <tap.h>
+
+#include <pipe.h>
+#include <canvas.h>
+
+struct pipe pipes[3] = {
+    {1, 1, 1, 1, 1},
+    {1, 1, 1, 1, 1},
+    {1, 1, 1, 1, 1}
+};
+
+static void test_order(const char *order, struct pipe_cell_list *list);
+
+static void test_order(const char *order, struct pipe_cell_list *list) {
+    struct pipe_cell *p;
+    size_t i = 0;
+    for(p = list->head, i = 0; p; p = p->next, i++)
+        ok(p->pipe_char[0] == order[i], "pipe char %d is %c", i, order[i]);
+    if(i > 0) {
+        ok(list->head->pipe_char[0] == order[0],
+                "list head is %c", order[0]);
+        ok(list->tail->pipe_char[0] == order[strlen(order) - 1],
+                "list tail is %c", order[strlen(order) - 1]);
+    }
+}
+
+int main(int argc, char **argv) {
+    plan(25);
+
+    struct pipe_cell_list list;
+    pipe_cell_list_init(&list);
+
+    pipe_cell_list_push(&list, "A", &pipes[0]);
+    pipe_cell_list_push(&list, "B", &pipes[1]);
+    pipe_cell_list_push(&list, "C", &pipes[2]);
+    pipe_cell_list_push(&list, "D", &pipes[0]);
+
+    diag("Init list as DCBA");
+    test_order("DCBA", &list);
+
+    diag("Remove last pipe with index 0 (A)");
+    pipe_cell_list_remove(&list, &pipes[0]);
+    test_order("DCB", &list);
+
+    diag("Remove next pipe with index 0 (D)");
+    pipe_cell_list_remove(&list, &pipes[0]);
+    test_order("CB", &list);
+
+    diag("Remove nonexistent pipe with index 0");
+    pipe_cell_list_remove(&list, &pipes[0]);
+    test_order("CB", &list);
+
+    diag("Remove pipe with index 1 (B)");
+    pipe_cell_list_remove(&list, &pipes[1]);
+    test_order("C", &list);
+
+    diag("Remove pipe with index 2 (C)");
+    pipe_cell_list_remove(&list, &pipes[2]);
+    test_order("", &list);
+
+    diag("Remove nonexistent pipe from zero-length list");
+    pipe_cell_list_remove(&list, &pipes[2]);
+    test_order("", &list);
+
+    diag("Add pipe with index 0 (E)");
+    pipe_cell_list_push(&list, "E", &pipes[0]);
+    test_order("E", &list);
+
+    done_testing();
+    return 0;
+}

--- a/t/pipe_cell_list.c
+++ b/t/pipe_cell_list.c
@@ -6,7 +6,7 @@
 #include <tap.h>
 
 #include <pipe.h>
-#include <canvas.h>
+#include <pipe_cell_list.h>
 
 struct pipe pipes[3] = {
     {1, 1, 1, 1, 1},

--- a/t/test_cbuf.c
+++ b/t/test_cbuf.c
@@ -1,6 +1,6 @@
 #include <tap.h>
 
-#include <canvas.h>
+#include <location_buffer.h>
 
 #define BUF_SZ 3
 

--- a/t/test_cbuf.c
+++ b/t/test_cbuf.c
@@ -1,0 +1,41 @@
+#include <tap.h>
+
+#include <canvas.h>
+
+#define BUF_SZ 3
+
+int main(int argc, char **argv) {
+    plan(13);
+
+    struct location_buffer buf;
+    location_buffer_init(&buf, BUF_SZ);
+    cmp_ok(buf.max, "==", BUF_SZ, "Inited size to %d", BUF_SZ);
+    cmp_ok(buf.size, "==", 0, "Inited size is 0");
+    cmp_ok(buf.head, "==", 0, "Initial head is 0");
+
+    ok(location_buffer_head(&buf) == NULL, "Default head is NULL");
+    ok(location_buffer_tail(&buf) == NULL, "Default tail is NULL");
+
+    diag("Pushing '1' to buf");
+    location_buffer_push(&buf, 1);
+    cmp_ok(*location_buffer_head(&buf), "==", 1, "Head points to '1'");
+    cmp_ok(*location_buffer_tail(&buf), "==", 1, "Tail points to '1'");
+
+    diag("Pushing '2' to buf");
+    location_buffer_push(&buf, 2);
+    cmp_ok(*location_buffer_head(&buf), "==", 2, "Head points to '2'");
+    cmp_ok(*location_buffer_tail(&buf), "==", 1, "Tail points to '1'");
+
+    diag("Pushing '3' to buf");
+    location_buffer_push(&buf, 3);
+    cmp_ok(*location_buffer_head(&buf), "==", 3, "Head points to '3'");
+    cmp_ok(*location_buffer_tail(&buf), "==", 1, "Tail points to '1'");
+
+    diag("Pushing '4' to buf: should loop");
+    location_buffer_push(&buf, 4);
+    cmp_ok(*location_buffer_head(&buf), "==", 4, "Head points to '4'");
+    cmp_ok(*location_buffer_tail(&buf), "==", 2, "Tail points to '2'");
+
+    done_testing();
+    return 0;
+}


### PR DESCRIPTION
If the `--max=N` option is passed to `cpipes`, the tail of each pipe will be erased after each movement, fixing the length of the pipe at `N` characters.

Doing this well requires us to store a list of characters that have been drawn to each grid cell, so that if we erase the tail of a pipe we know what character to redraw, if any.