### PR TITLE
Fix (benign) memory leak with --max

### DIFF
--- a/src/cpipes.c
+++ b/src/cpipes.c
@@ -186,7 +186,11 @@ cleanup:
 
     canvas_free(&canvas);
     free(custom_colors);
+
+    for(size_t i = 0; i < num_pipes; i++)
+        free_pipe(&pipes[i]);
     free(pipes);
+
     palette_destroy(&canvas.palette);
     return 0;
 }

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -344,6 +344,14 @@ cpipes_errno init_pipe(struct pipe *pipe, struct canvas *canvas,
     return 0;
 }
 
+// Free pipe, including the location buffer (if set)
+void free_pipe(struct pipe *pipe) {
+    if(pipe->locations) {
+        location_buffer_free(pipe->locations);
+        free(pipe->locations);
+    }
+}
+
 /** Move a pipe by the amount given by the current state. If
  * `multicolumn_adjust` was called and detected that multicolumn characters are
  * in use, the `states` variable will have been updated to reflect the width of

--- a/src/pipe.h
+++ b/src/pipe.h
@@ -38,6 +38,7 @@ struct palette;
 
 cpipes_errno init_pipe(struct pipe *pipe, struct canvas *canvas,
         int initial_state, unsigned int max_len);
+void free_pipe(struct pipe *pipe);
 void move_pipe(struct pipe *pipe, struct canvas *canvas);
 bool wrap_pipe(struct pipe *pipe, struct canvas *canvas);
 void erase_pipe_tail(struct pipe *pipe, struct canvas *canvas);


### PR DESCRIPTION
Explicitly free the memory used by the location buffers of pipes.