### PR TITLE
Fix segfault/memory errors when resizing terminal

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -59,11 +59,18 @@ void canvas_free(struct canvas *canvas) {
  */
 void canvas_erase_tail(struct canvas *c,
         unsigned int tail, struct pipe *p) {
+    unsigned int y = tail / c->width;
+    unsigned int x = tail % c->width;
+
+    // If the canvas has shrunk, the tail of the pipe can fall outside of the
+    // current bounds. The cell should already have been freed and will be
+    // invisible, so we can just skip it.
+    if(x >= c->width || y >= c->height)
+        return;
+
     struct pipe_cell_list *cells = &c->cells[tail];
     struct pipe_cell *head = cells->head;
 
-    unsigned int y = tail / c->width;
-    unsigned int x = tail % c->width;
     pipe_cell_list_remove(cells, p);
     if(!cells->head) {
         mvaddstr(y, x, " ");

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -382,13 +382,13 @@ bool wrap_pipe(struct pipe *pipe, struct canvas *canvas){
     if(pipe->x < 0 || (unsigned int) pipe->x >= width
             || pipe->y < 0 || (unsigned int) pipe->y >= canvas->height){
         if(pipe->x < 0)
-            pipe->x += width;
+            pipe->x = width - 1;
         if(pipe->y < 0)
-            pipe->y += canvas->height;
+            pipe->y = canvas->height - 1;
         if((unsigned int) pipe->x >= canvas->width)
-            pipe->x -= width;
+            pipe->x = 0;
         if((unsigned int) pipe->y >= canvas->height)
-            pipe->y -= canvas->height;
+            pipe->y = 0;
         return true;
     }
     return false;

--- a/src/render.c
+++ b/src/render.c
@@ -322,7 +322,9 @@ void animate(int fps, anim_function renderer, struct canvas *canvas,
 
         // If we received a SIGWINCH, update width and height
         if(key == KEY_RESIZE) {
-            getmaxyx(stdscr, canvas->height, canvas->width);
+            int width, height;
+            getmaxyx(stdscr, height, width);
+            canvas_resize(canvas, width, height);
         }else if(key != ERR) {
             // Any actual keypresses should quit the program.
             break;


### PR DESCRIPTION
When the --max option is given and terminal is resized, canvas_resize
must be called in order to initialise the pipe cell list in the new
section of the terminal. If the terminal has shrunk, cpipes should not
attempt to pop characters out of cells in the newly-freed memory
region. Those cells are invisible anyway.

For large terminal size changes, wrapping the pipe location by adding or
subtracting the terminal with or height can be insufficient. This commit
changes the behaviour of wrap_pipe to ensure the pipe always ends up in
a valid region of the terminal.